### PR TITLE
Upgrade remotedev-app to v0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ export default initialState => {
     applyMiddleware(thunk),
     global.reduxNativeDevTools ? global.reduxNativeDevTools(/*options*/) : nope => nope,
   );
-  return createStore(reducer, initialState, enhancer);
+  const store = createStore(reducer, initialState, enhancer);
+  if (global.reduxNativeDevTools) {
+    global.reduxNativeDevTools.updateStore(store);
+  }
+  return store;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Name                  | Description
 -------------         | -------------
 `filters`             | *Map of arrays* named `whitelist` or `blacklist` to filter action types.
 `maxAge`              | *Number* of maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `30`.
+`actionCreators`      | *Array* or *Object* of action creators to dispatch remotely. See the [example](https://github.com/zalmoxisus/remote-redux-devtools/commit/b54652930dfd4e057991df8471c343957fd7bff7).
 
-These two option is same with [remote-redux-devtools#parameters](https://github.com/zalmoxisus/remote-redux-devtools#parameters).
+These options are same with [remote-redux-devtools#parameters](https://github.com/zalmoxisus/remote-redux-devtools#parameters).
 
 ## Development
 

--- a/app/containers/ReduxDevTools/createRemoteStore.js
+++ b/app/containers/ReduxDevTools/createRemoteStore.js
@@ -1,0 +1,49 @@
+import { stringify } from 'jsan';
+import createDevStore from 'remotedev-app/lib/store/createDevStore';
+import updateState from 'remotedev-app/lib/store/updateState';
+
+let store;
+let worker;
+let workerOnMessage;
+
+export const createRemoteStore = onError => {
+  store = createDevStore((type, action, id, bareState) => {
+    let state = bareState;
+    if (type !== 'IMPORT') state = stringify(state);
+
+    if (worker) {
+      worker.postMessage({
+        method: 'emitReduxMessage',
+        content: { type, action, state },
+      });
+    }
+  });
+  workerOnMessage = (message) => {
+    const { data } = message;
+    if (data && data.__IS_REDUX_NATIVE_MESSAGE__) {
+      const { content: msg } = data;
+      if (msg.type === 'ERROR') {
+        onError(msg.payload);
+        return;
+      }
+      updateState(store, msg);
+    }
+  };
+  return store;
+};
+
+export const setWorker = instance => {
+  if (worker) {
+    worker.removeEventListener('message', workerOnMessage);
+  }
+  if (instance) {
+    instance.addEventListener('message', workerOnMessage);
+  }
+  worker = instance;
+};
+
+export const importState = state =>
+  store.liftedStore.importState(state);
+
+export const exportState = () =>
+  store.liftedStore.getState();

--- a/app/containers/ReduxDevTools/reduxNativeDevTools.js
+++ b/app/containers/ReduxDevTools/reduxNativeDevTools.js
@@ -118,7 +118,7 @@ function start() {
 
   // Because the worker message not have notify the remote JS runtime
   // we need to regularly update JS runtime
-  setInterval(function(){}, 222); // eslint-disable-line
+  global.__RND_INTERVAL__ = setInterval(function(){}, 222); // eslint-disable-line
 }
 
 function monitorReducer(state = {}, action) {

--- a/app/containers/ReduxDevTools/reduxNativeDevTools.js
+++ b/app/containers/ReduxDevTools/reduxNativeDevTools.js
@@ -2,6 +2,7 @@
 
 import { stringify, parse } from 'jsan';
 import instrument from 'redux-devtools-instrument';
+import { evalAction, getActionsArray } from 'remotedev-utils';
 
 function configureStore(next, subscriber, options) {
   return instrument(subscriber, options)(next);
@@ -16,10 +17,14 @@ let lastAction;
 let filters;
 let isExcess;
 let started;
+let actionCreators;
 
 function init(options) {
   if (options.filters) {
     filters = options.filters;
+  }
+  if (options.actionCreators) {
+    actionCreators = () => getActionsArray(options.actionCreators);
   }
 }
 
@@ -51,19 +56,34 @@ function filterStagedActions(state) {
   };
 }
 
+function getLiftedState() {
+  return filterStagedActions(store.liftedStore.getState());
+}
+
 function relay(type, state, action, nextActionId) {
   if (filters && isFiltered(action)) return;
   const message = {
     type,
     id: 'redux-native-devtools',
   };
-  if (state) message.payload = stringify(state);
-  if (action) {
+  if (state) message.payload = type === 'ERROR' ? state : stringify(state);
+  if (type === 'ACTION') {
     message.action = stringify(action);
     message.isExcess = isExcess;
+    message.nextActionId = nextActionId;
+  } else if (action) {
+    message.action = action;
   }
-  if (nextActionId) message.nextActionId = stringify(nextActionId);
   postMessage({ __IS_REDUX_NATIVE_MESSAGE__: true, content: message });
+}
+
+function dispatchRemotely(action) {
+  try {
+    const result = evalAction(action, actionCreators);
+    store.dispatch(result);
+  } catch (e) {
+    relay('ERROR', e.message);
+  }
 }
 
 function handleMessages(message) {
@@ -73,11 +93,11 @@ function handleMessages(message) {
       nextLiftedState: parse(message.state),
     });
   }
-  if (message.type === 'UPDATE' || message.type === 'IMPORT' || message.type === 'START') {
-    relay('STATE', filterStagedActions(store.liftedStore.getState()));
+  if (message.type === 'UPDATE' || message.type === 'IMPORT') {
+    relay('STATE', getLiftedState());
   }
   if (message.type === 'ACTION') {
-    store.dispatch(message.action);
+    dispatchRemotely(message.action);
   } else if (message.type === 'DISPATCH') {
     store.liftedStore.dispatch(message.action);
   }
@@ -93,7 +113,8 @@ function start() {
       handleMessages(content);
     }
   });
-  relay('STATE', store.liftedStore.getState());
+  if (typeof actionCreators === 'function') actionCreators = actionCreators();
+  relay('STATE', getLiftedState(), actionCreators);
 
   // Because the worker message not have notify the remote JS runtime
   // we need to regularly update JS runtime

--- a/app/containers/ReduxDevTools/reduxNativeDevTools.js
+++ b/app/containers/ReduxDevTools/reduxNativeDevTools.js
@@ -142,7 +142,7 @@ function handleChange(state, liftedState, maxAge) {
   }
 }
 
-export default (options = {}) => {
+const reduxNatieDevToools = (options = {}) => {
   init(options);
   const maxAge = options.maxAge || 30;
   return next => (reducer, initialState) => {
@@ -157,3 +157,9 @@ export default (options = {}) => {
     return store;
   };
 };
+
+reduxNatieDevToools.updateStore = newStore => {
+  store = newStore;
+};
+
+export default reduxNatieDevToools;

--- a/app/containers/ReduxDevTools/reduxNativeDevTools.js
+++ b/app/containers/ReduxDevTools/reduxNativeDevTools.js
@@ -72,7 +72,7 @@ function relay(type, state, action, nextActionId) {
     message.isExcess = isExcess;
     message.nextActionId = nextActionId;
   } else if (action) {
-    message.action = action;
+    message.action = stringify(action);
   }
   postMessage({ __IS_REDUX_NATIVE_MESSAGE__: true, content: message });
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-devtools-instrument": "^1.0.1",
-    "remotedev-app": "^0.5.0-alpha-2",
+    "remotedev-app": "^0.6.0",
     "ws": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "redux": "^3.5.2",
     "redux-devtools-instrument": "^1.0.1",
     "remotedev-app": "^0.6.0",
+    "remotedev-utils": "0.0.3",
     "ws": "^1.1.0"
   }
 }


### PR DESCRIPTION
Upgrade remotedev-app to v0.6, and sync `remote-redux-devtools` updates, the new feature is [`Use action creators for Dispatcher`](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.4.0), we can set `actionCreators` in `reduxNativeDevTools` options:

```js
import { createStore, applyMiddleware, compose } from 'redux';
import thunk from 'redux-thunk';
import reducer from '../reducers';
import * as actionCreators from '../actions/counter'; 

export default initialState => {
  const enhancer = compose(
    applyMiddleware(thunk),
    global.reduxNativeDevTools ?
      global.reduxNativeDevTools({ actionCreators }) :
      f => f,
  );
  return createStore(reducer, initialState, enhancer);
}
```