### PR TITLE
Devtools path changed in RN .  Fixes broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Debugger part is reference from [react-native](https://github.com/facebook/r
 
 The React Developer Tools part from [react-devtools/shells/electron](https://github.com/facebook/react-devtools/tree/master/shells/electron), it will open a WebSocket server (port: `8097`) to waiting React Native connection.
 
-If you're debugging with a real device, you need to edit [node_modules/react-native/Libraries/Devtools/setupDevtools.js](https://github.com/facebook/react-native/tree/master/Libraries/Devtools/setupDevtools.js#L17).
+If you're debugging with a real device, you need to edit [node_modules/react-native/Libraries/Core/Devtools/setupDevtools.js](https://github.com/facebook/react-native/tree/master/Libraries/Core/Devtools/setupDevtools.js#L17).
 
 #### Note for Android
 


### PR DESCRIPTION
RN changed path for setupDevTools in [29cc82](https://github.com/facebook/react-native/commit/292cc82d0ebc437a6f1cdd2e972b3917b7ee05a4#diff-8a2d58614a696a381ddeeba0f0dc691b)