### PR TITLE
Pass filters to 'isFiltered' call to satisfy expected signature

### DIFF
--- a/app/worker/reduxAPI.js
+++ b/app/worker/reduxAPI.js
@@ -41,7 +41,7 @@ function getLiftedState(store) {
 }
 
 function relay(type, state, instance, action, nextActionId) {
-  if (filters && isFiltered(action)) return;
+  if (filters && isFiltered(action, filters)) return;
   const message = {
     type,
     id: instance.id,


### PR DESCRIPTION
Without passing the filters object, the `filters` argument won't work.