### PR TITLE
Add `DevTools Author` extension by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ $ npm run dev:webpack
 $ npm run dev:electron
 
 # Run on production
+$ npm run fetch-ext # Fetch chrome extensions for prod usage
 $ npm run build
 $ npm start
 

--- a/electron/extensions.js
+++ b/electron/extensions.js
@@ -27,6 +27,6 @@ export default async () => {
       if (extension.version === version) return;
       BrowserWindow.removeDevToolsExtension(name);
     }
-    BrowserWindow.addDevToolsExtension('devtools_author/');
+    BrowserWindow.addDevToolsExtension(path.join(__dirname, 'devtools_author/'));
   }
 };

--- a/electron/extensions.js
+++ b/electron/extensions.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { BrowserWindow } from 'electron';
 
 export default async () => {
@@ -16,6 +18,8 @@ export default async () => {
       } catch (e) {} // eslint-disable-line
     }
   } else {
+    if (!fs.existsSync(path.join(__dirname, 'devtools_author'))) return;
+
     const name = 'DevTools Author';
     const extension = BrowserWindow.getDevToolsExtensions()[name];
     const { version } = require('./devtools_author/manifest.json'); // eslint-disable-line

--- a/electron/extensions.js
+++ b/electron/extensions.js
@@ -1,3 +1,5 @@
+import { BrowserWindow } from 'electron';
+
 export default async () => {
   if (process.env.NODE_ENV === 'development') {
     const installer = require('electron-devtools-installer'); // eslint-disable-line
@@ -5,12 +7,22 @@ export default async () => {
     const extensions = [
       'REACT_DEVELOPER_TOOLS',
       'REDUX_DEVTOOLS',
+      'egfhcfdfnajldliefpdoaojgahefjhhi', // DevTools Author
     ];
     const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
     for (const name of extensions) {
       try {
-        await installer.default(installer[name], forceDownload);
+        await installer.default(installer[name] || name, forceDownload);
       } catch (e) {} // eslint-disable-line
     }
+  } else {
+    const name = 'DevTools Author';
+    const extension = BrowserWindow.getDevToolsExtensions()[name];
+    const { version } = require('./devtools_author/manifest.json'); // eslint-disable-line
+    if (extension) {
+      if (extension.version === version) return;
+      BrowserWindow.removeDevToolsExtension(name);
+    }
+    BrowserWindow.addDevToolsExtension('devtools_author/');
   }
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev:electron": "cross-env NODE_ENV=development electron -r babel-core/register -r ./electron/debug .",
     "lint": "eslint .",
     "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js",
-    "fetch-rdt": "./scripts/fetch-react-devtools.sh"
+    "fetch-rdt": "./scripts/fetch-react-devtools.sh",
+    "fetch-ext": "electron ./scripts/fetch-extension.js"
   },
   "repository": {
     "type": "git",
@@ -49,6 +50,7 @@
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.0.0",
     "expect": "^1.20.2",
+    "fs-extra": "^2.0.0",
     "json-loader": "^0.5.4",
     "mobx": "^2.6.2",
     "mobx-remotedev": "^0.2.2",

--- a/scripts/fetch-extension.js
+++ b/scripts/fetch-extension.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+const fs = require('fs-extra');
+const path = require('path');
+const download = require(
+  'electron-devtools-installer/dist/downloadChromeExtension'
+).default;
+
+const DEVTOOLS_AUTHOR = 'egfhcfdfnajldliefpdoaojgahefjhhi';
+
+download(DEVTOOLS_AUTHOR, true)
+  .then(extensionFolder => {
+    fs.copy(
+      extensionFolder,
+      path.join(__dirname, '../dist/devtools_author'
+    ), () => process.exit());
+  }).catch(() => process.exit(1));

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -28,5 +28,6 @@ export default {
     // just avoid warning.
     // this is not really used from ws. (it used fallback)
     'bufferutil', 'utf-8-validate',
+    './devtools_author/manifest.json',
   ],
 };


### PR DESCRIPTION
Add [`DevTools Author`](https://github.com/micjamking/devtools-author) extension by default, it's a pre-downloaded extension folder (`dist/devtools_author`), not install by devtools-installer.

We can see `Author Settings` in DevTools tab bar:

<img width="561" alt="2017-01-21 6 45 40" src="https://cloud.githubusercontent.com/assets/3001525/22173900/c41b75a0-e00a-11e6-865b-4d6836ca87fa.png">

We need to allow custom UI themes in DevTools: *Settings* > *Experiments* > check **Allow custom UI themes**

![2017-01-21 6 54 12](https://cloud.githubusercontent.com/assets/3001525/22173908/08a24d16-e00b-11e6-9cbd-7d49745b6660.png)
> Use `Azure` theme and Dark Devtools theme