### PR TITLE
Use `react-devtools-core/standalone` instead of fork

### DIFF
--- a/app/containers/ReactInspector.js
+++ b/app/containers/ReactInspector.js
@@ -1,31 +1,16 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
-// Take from https://github.com/facebook/react-devtools/blob/master/shells/electron/src/ui.js
-
 /* eslint import/no-extraneous-dependencies: 0 import/no-unresolved: 0 */
 
-import ws from 'ws';
 import { connect } from 'react-redux';
 import React, { Component, PropTypes } from 'react';
+import ReactServer from 'react-devtools-core/standalone';
 
-import backendScript from 'raw!../react-devtools/shells/electron/build/backend.js';
-import Panel from '../react-devtools/frontend/Panel';
-
-const getNewKey = () => `react-panel${Math.random().toString().substr(2, 10)}`;
+const containerId = 'react-devtools-container';
 
 const styles = {
-  waiting: {
-    WebkitUserSelect: 'none',
-    textAlign: 'center',
-    padding: '30px',
-    color: '#aaa',
+  container: {
+    display: 'flex',
+    height: '100%',
+    justifyContent: 'center',
   },
 };
 
@@ -38,13 +23,6 @@ const styles = {
 export default class ReactInspector extends Component {
   static propTypes = {
     debugger: PropTypes.object,
-  };
-
-  state = {
-    connected: false,
-    message: 'Waiting for a connection from React Native',
-    panelKey: getNewKey(),
-    wall: null,
   };
 
   componentDidMount() {
@@ -64,6 +42,10 @@ export default class ReactInspector extends Component {
     }
   }
 
+  shouldComponentUpdate() {
+    return false;
+  }
+
   componentWillUnmount() {
     if (this.server) {
       this.server.close();
@@ -71,130 +53,20 @@ export default class ReactInspector extends Component {
     }
   }
 
-  onDisconnected = () => {
-    this.setState({ connected: false });
-  };
-
-  onError = e => {
-    this.setState({
-      connected: false,
-      message: e.code === 'EADDRINUSE' ?
-        'Another instance of DevTools is running' :
-        `Unknown error (${e.message})`,
-    });
-  };
-
-  reload = payload => {
-    this.setState({ connected: true, panelKey: getNewKey(), ...payload });
-  };
-
-  initialize = socket => {
-    socket.send(`eval:${backendScript}`);
-    const listeners = [];
-
-    socket.onmessage = evt => {
-      if (evt.data === 'attach:agent') {
-        return;
-      }
-      const data = JSON.parse(evt.data);
-      if (data.$close || data.$error) {
-        this.onDisconnected();
-        socket.onmessage = msg => {
-          if (msg.data === 'attach:agent') {
-            this.initialize(socket);
-          }
-        };
-        return;
-      }
-      if (data.$open) {
-        return; // ignore
-      }
-      listeners.forEach(fn => fn(data));
-    };
-    this.reload({
-      wall: {
-        listen(fn) {
-          listeners.push(fn);
-        },
-        send(data) {
-          if (
-            data.events &&
-            data.events.length &&
-            data.events[0].evt === 'hideHighlight'
-          ) {
-            return;
-          }
-          socket.send(JSON.stringify(data));
-        },
-        disconnect() {
-          socket.close();
-        },
-      },
-    });
-  }
-
-  /**
-   * When the Electron app is running in "server mode"
-   */
-  startServer = (port = 8097) => {
-    const options = { port };
-    if (process.env.REACT_ONLY_FOR_LOCAL) {
-      options.host = 'localhost';
-    }
-    const server = new ws.Server(options);
-    let connected = false;
-    server.on('connection', socket => {
-      if (connected) {
-        console.warn('[React DevTools] Only one connection allowed at a time');
-        socket.close();
-        return;
-      }
-      connected = true;
-      socket.onerror = err => {
-        connected = false;
-        this.onDisconnected();
-        console.log('[React DevTools] Error with websocket connection', err);
-      };
-      socket.onclose = () => {
-        connected = false;
-        this.onDisconnected();
-      };
-      this.initialize(socket);
-    });
-
-    server.on('error', e => {
-      this.onError(e);
-      console.error('[React DevTools] Failed to start the DevTools server', e);
-      this.restartTimeout = setTimeout(() => this.startServer(port), 1000);
-    });
-
-    return {
-      close: () => {
-        connected = false;
-        this.onDisconnected();
-        clearTimeout(this.restartTimeout);
-        server.close();
-      },
-    };
-  }
-
-  renderWaiting() {
-    return (
-      <h2 style={styles.waiting}>{this.state.message}</h2>
-    );
+  startServer(port = 8097) {
+    return ReactServer
+      .setContentDOMNode(document.getElementById(containerId))
+      .startServer(port);
   }
 
   render() {
-    if (!this.state.connected) {
-      return this.renderWaiting();
-    }
     return (
-      <Panel
-        key={this.state.panelKey}
-        reload={this.reload}
-        alreadyFoundReact
-        inject={done => done(this.state.wall)}
-      />
+      <div
+        id={containerId}
+        style={styles.container}
+      >
+        <div id="waiting"><h2>Waiting for React to connect…</h2></div>
+      </div>
     );
   }
 }

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -53,7 +53,7 @@ const shutdownJSRuntime = (status, statusMessage) => {
 };
 
 const connectToDebuggerProxy = () => {
-  const ws = WebSocket.connect(`ws://${host}:${port}/debugger-proxy?role=debugger&name=Chrome`);
+  const ws = new WebSocket(`ws://${host}:${port}/debugger-proxy?role=debugger&name=Chrome`);
 
   const { setDebuggerStatus } = actions;
   ws.onopen = () => setDebuggerStatus();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,20 +9,14 @@ cache:
   - node_modules -> package.json
 
 install:
-  - ps: Start-FileDownload 'http://www.ocamlpro.com/pub/ocpwin/flow-builds/archives/flow-0.19.1-windows-20151211.zip'
-  - 7z x flow-0.19.1-windows-20151211.zip
-  - set PATH=%cd%\flow-0.19.1-windows-20151211;%PATH%
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm
   - npm install
-  - git clone https://github.com/jhen0409/react-devtools.git app\react-devtools
-  - rm app\react-devtools\.babelrc
   - cd patch && npm install && cd ..
 
 test_script:
   - node --version
   - npm --version
-  - npm run build:devtools
   - npm run lint
   - npm run build
   - npm test

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -17,6 +17,13 @@ html, body {
   left: 0;
   white-space: pre;
 }
+#waiting {
+  -webkit-user-select: none;
+  text-align: center;
+  padding: 30px;
+  color: #aaa;
+  align-self: center;
+}
 @media print {
   @page {
     size: auto;

--- a/dist/package.json
+++ b/dist/package.json
@@ -11,6 +11,7 @@
   "author": "Jhen <developer@jhen.me>",
   "license": "MIT",
   "dependencies": {
+    "react-devtools-core": "^2.0.4",
     "source-map-support": "^0.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "pack-windows": "npm run prepack && ./scripts/package-windows.sh",
     "pack": "./scripts/package-macos.sh && ./scripts/package-linux.sh && ./scripts/package-windows.sh",
     "start": "cd dist && cross-env NODE_ENV=production electron ./",
-    "build:devtools": "cross-env NODE_ENV=production webpack --config webpack/devtools.backend.babel.js --progress --profile --colors",
     "build:main": "cross-env NODE_ENV=production webpack --config webpack/main.prod.babel.js --progress --profile --colors",
     "build:renderer": "cross-env NODE_ENV=production webpack --config webpack/renderer.prod.babel.js --progress --profile --colors",
     "build": "npm run build:main && npm run build:renderer",
-    "dev:webpack": "npm run build:devtools && webpack-dev-server --config webpack/renderer.dev.babel.js --hot --inline --colors",
+    "dev:webpack": "webpack-dev-server --config webpack/renderer.dev.babel.js --hot --inline --colors",
     "dev:electron": "cross-env NODE_ENV=development electron -r babel-core/register -r ./electron/debug .",
     "lint": "eslint .",
-    "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js",
-    "fetch-rdt": "./scripts/fetch-react-devtools.sh"
+    "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js"
   },
   "repository": {
     "type": "git",
@@ -68,6 +66,7 @@
     "node-watch": "^0.4.0",
     "react": "^15.4.0",
     "react-addons-create-fragment": "^15.4.0",
+    "react-devtools-core": "^2.0.4",
     "react-dock": "^0.2.3",
     "react-dom": "^15.4.0",
     "react-redux": "^4.4.5",
@@ -78,6 +77,6 @@
     "remotedev-monitor-components": "0.0.5",
     "remotedev-slider": "^1.1.1",
     "remotedev-utils": "^0.1.1",
-    "ws": "^1.1.1"
+    "ws": "^2.0.0"
   }
 }

--- a/scripts/fetch-react-devtools.sh
+++ b/scripts/fetch-react-devtools.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-rm -rf app/react-devtools
-git clone https://github.com/jhen0409/react-devtools.git app/react-devtools
-cd app/react-devtools && git checkout rndebugger
-cd ../..
-rm -rf app/react-devtools/.*
-
-npm run build:devtools

--- a/test/e2e/app.spec.js
+++ b/test/e2e/app.spec.js
@@ -76,7 +76,7 @@ describe('Application launch', function spec() {
   it('should show waiting message on React DevTools', async () => {
     const { client } = this.app;
     const exist = await client.isExisting(
-      '//h2[text()="Waiting for a connection from React Native"]'
+      '//h2[text()="Waiting for React to connect…"]'
     );
     expect(exist).toBe(true);
   });

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -25,8 +25,9 @@ export default {
     }],
   },
   externals: [
+    'react-devtools-core/standalone',
     // just avoid warning.
     // this is not really used from ws. (it used fallback)
-    'bufferutil', 'utf-8-validate',
+    'utf-8-validate', 'bufferutil',
   ],
 };

--- a/webpack/devtools.backend.babel.js
+++ b/webpack/devtools.backend.babel.js
@@ -1,8 +1,0 @@
-import { join } from 'path';
-import config from '../app/react-devtools/shells/electron/webpack.backend';
-
-config.context = join(__dirname, '../app/react-devtools/shells/electron');
-delete config.module.loaders[0].exclude;
-config.module.loaders[0].include = join(__dirname, '../app/react-devtools');
-
-export default config;


### PR DESCRIPTION
`react-devtools-core` is official npm package is now used for [Nuclide](https://github.com/facebook/nuclide), we can just use it instead of the complicated fork.

Big thanks @gaearon to accept some requests from me. (https://github.com/facebook/react-devtools/issues/489)

Just the following PRs waiting for upstream:

- https://github.com/facebook/react-devtools/pull/508
- https://github.com/facebook/react-devtools/pull/509