### PR TITLE
[macOS] Add TouchBar integration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,10 @@
     "strict": 0,
     "no-console": 0,
     "no-param-reassign": ["error", { "props": false }],
-    "no-underscore-dangle": ["error", { "allow": ["__IS_REDUX_NATIVE_MESSAGE__"] }],
+    "no-underscore-dangle": [
+      "error",
+      { "allow": ["__IS_REDUX_NATIVE_MESSAGE__", "__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__"] }
+    ],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "import/prefer-default-export": 0
   }

--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,14 @@
-import { webFrame } from 'electron';
+import { remote, webFrame } from 'electron';
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './containers/App';
 import configureStore from './store/configureStore';
+
+if (process.platform === 'darwin') {
+  // Reset TouchBar when reload the app
+  remote.getCurrentWindow().setTouchBar([]);
+}
 
 webFrame.setZoomFactor(1);
 webFrame.setZoomLevelLimits(1, 1);

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -26,6 +26,10 @@ const workerOnMessage = message => {
   if (message.data && message.data.__IS_REDUX_NATIVE_MESSAGE__) {
     return true;
   }
+  if (message.data && message.data.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__) {
+    // TODO: Set Touch bar
+    return false;
+  }
   socket.send(JSON.stringify(message.data));
 };
 

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -93,7 +93,7 @@ const connectToDebuggerProxy = () => {
       // Otherwise, pass through to the worker.
       if (!worker) return;
       if (object.method === 'executeApplicationScript') {
-        object.enableXHRInspect = localStorage.enableXHRInspect === 'enabled';
+        object.enableNetworkInspect = localStorage.enableNetworkInspect === 'enabled';
       }
       worker.postMessage(object);
     }

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -13,6 +13,7 @@ import WebSocket from 'ws';
 import { bindActionCreators } from 'redux';
 import Worker from 'worker?name=RNDebuggerWorker.js!../worker'; // eslint-disable-line
 import * as debuggerActions from '../actions/debugger';
+import { setAvailableDevMenuMethods } from './touchBarBuilder';
 
 const { SET_DEBUGGER_LOCATION } = debuggerActions;
 
@@ -26,8 +27,9 @@ const workerOnMessage = message => {
   if (message.data && message.data.__IS_REDUX_NATIVE_MESSAGE__) {
     return true;
   }
-  if (message.data && message.data.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__) {
-    // TODO: Set Touch bar
+  const list = message.data && message.data.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__;
+  if (list) {
+    setAvailableDevMenuMethods(list, worker);
     return false;
   }
   socket.send(JSON.stringify(message.data));
@@ -51,6 +53,7 @@ const shutdownJSRuntime = (status, statusMessage) => {
   const { setDebuggerWorker } = actions;
   if (worker) {
     worker.terminate();
+    setAvailableDevMenuMethods([]);
   }
   worker = null;
   setDebuggerWorker(null, status, statusMessage);

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -92,6 +92,9 @@ const connectToDebuggerProxy = () => {
     } else {
       // Otherwise, pass through to the worker.
       if (!worker) return;
+      if (object.method === 'executeApplicationScript') {
+        object.enableXHRInspect = localStorage.enableXHRInspect === 'enabled';
+      }
       worker.postMessage(object);
     }
   };

--- a/app/middlewares/reduxAPI.js
+++ b/app/middlewares/reduxAPI.js
@@ -82,16 +82,12 @@ export default inStore => {
       const instances = state.instances;
       const id = getActiveInstance(instances);
       const liftedState = instances.states[id];
-      if (
-        (!action.action || !action.action.dontUpdateTouchBarSlider) &&
-        liftedState && liftedState.computedStates.length > 1
-      ) {
+      if (liftedState && liftedState.computedStates.length > 1) {
         setReduxDevToolsMethods(true, actions.liftedDispatch);
-        updateSliderContent(liftedState);
-      }
-      if (liftedState && liftedState.computedStates.length <= 1) {
+      } else if (liftedState && liftedState.computedStates.length <= 1) {
         setReduxDevToolsMethods(false);
       }
+      updateSliderContent(liftedState, action.action && action.action.dontUpdateTouchBarSlider);
       return;
     }
     return next(action);

--- a/app/middlewares/reduxAPI.js
+++ b/app/middlewares/reduxAPI.js
@@ -77,14 +77,20 @@ export default inStore => {
       toWorker(action);
     }
     if (action.type === UPDATE_STATE || action.type === LIFTED_ACTION) {
-      setReduxDevToolsMethods(true, actions.liftedDispatch);
       next(action);
       const state = store.getState();
       const instances = state.instances;
       const id = getActiveInstance(instances);
       const liftedState = instances.states[id];
-      if (!action.action || !action.action.dontUpdateTouchBarSlider) {
+      if (
+        (!action.action || !action.action.dontUpdateTouchBarSlider) &&
+        liftedState && liftedState.computedStates.length > 1
+      ) {
+        setReduxDevToolsMethods(true, actions.liftedDispatch);
         updateSliderContent(liftedState);
+      }
+      if (liftedState && liftedState.computedStates.length <= 1) {
+        setReduxDevToolsMethods(false);
       }
       return;
     }

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -70,7 +70,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
   // Already setup
   if (enabled && sliderEnabled) return;
 
-  const handleSliderChange = (nextIndex, dontUpdateTouchBarSlider = true) =>
+  const handleSliderChange = (nextIndex, dontUpdateTouchBarSlider = false) =>
     dispatch({
       type: 'JUMP_TO_STATE',
       actionId: storeLiftedState.stagedActionIds[nextIndex],
@@ -82,14 +82,18 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
     value: 0,
     minValue: 0,
     maxValue: 0,
-    change: handleSliderChange,
+    change(nextIndex) {
+      if (nextIndex !== storeLiftedState.currentStateIndex) {
+        handleSliderChange(nextIndex, true);
+      }
+    },
   });
   rightBar.prev = new TouchBarButton({
     label: 'Prev',
     click() {
       const nextIndex = storeLiftedState.currentStateIndex - 1;
       if (nextIndex >= 0) {
-        handleSliderChange(nextIndex, false);
+        handleSliderChange(nextIndex);
       }
     },
   });
@@ -98,7 +102,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
     click() {
       const nextIndex = storeLiftedState.currentStateIndex + 1;
       if (nextIndex < storeLiftedState.computedStates.length) {
-        handleSliderChange(nextIndex, false);
+        handleSliderChange(nextIndex);
       }
     },
   });

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -78,13 +78,13 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       dontUpdateTouchBarSlider,
     });
 
-  leftBar.slider = new TouchBarSlider({
+  rightBar.slider = new TouchBarSlider({
     value: 0,
     minValue: 0,
     maxValue: 0,
     change: handleSliderChange,
   });
-  leftBar.prev = new TouchBarButton({
+  rightBar.prev = new TouchBarButton({
     label: 'Prev',
     click() {
       const nextIndex = storeLiftedState.currentStateIndex - 1;
@@ -93,7 +93,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       }
     },
   });
-  leftBar.next = new TouchBarButton({
+  rightBar.next = new TouchBarButton({
     label: 'Next',
     click() {
       const nextIndex = storeLiftedState.currentStateIndex + 1;
@@ -109,6 +109,6 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
 export const updateSliderContent = liftedState => {
   storeLiftedState = liftedState;
   const { currentStateIndex, computedStates } = liftedState;
-  leftBar.slider.maxValue = computedStates.length - 1;
-  leftBar.slider.value = currentStateIndex;
+  rightBar.slider.maxValue = computedStates.length - 1;
+  rightBar.slider.value = currentStateIndex;
 };

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -4,7 +4,6 @@ const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
 const currentWindow = remote.getCurrentWindow();
 
 let worker;
-let enableXHRInspect = false;
 const leftBar = {
   reload: null,
   enableXHRInspect: null,
@@ -44,14 +43,15 @@ export const setAvailableDevMenuMethods = (list, wkr) => {
   }
 
   if (list.includes('enableXHRInspect')) {
+    const disabled = () => localStorage.enableXHRInspect === 'disabled';
+    const getLabel = () => (disabled() ? 'Disable XHR Inspect' : 'Enable XHR Inspect');
+    const toggle = () => (disabled() ? 'enabled' : 'disabled');
     leftBar.enableXHRInspect = new TouchBarButton({
-      label: 'Enable XHR Inspect',
+      label: getLabel(),
       click: () => {
-        enableXHRInspect = !enableXHRInspect;
-        leftBar.enableXHRInspect.label = enableXHRInspect ?
-          'Disable XHR Inspect' :
-          'Enable XHR Inspect';
-        invokeDevMenuMethod({ name: 'enableXHRInspect', args: [enableXHRInspect] });
+        localStorage.enableXHRInspect = toggle();
+        leftBar.enableXHRInspect.label = getLabel();
+        invokeDevMenuMethod({ name: 'enableXHRInspect', args: [localStorage.enableXHRInspect] });
       },
     });
   }

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -110,9 +110,11 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
   resetTouchBar();
 };
 
-export const updateSliderContent = liftedState => {
+export const updateSliderContent = (liftedState, dontUpdateTouchBarSlider) => {
   storeLiftedState = liftedState;
-  const { currentStateIndex, computedStates } = liftedState;
-  rightBar.slider.maxValue = computedStates.length - 1;
-  rightBar.slider.value = currentStateIndex;
+  if (sliderEnabled && !dontUpdateTouchBarSlider) {
+    const { currentStateIndex, computedStates } = liftedState;
+    rightBar.slider.maxValue = computedStates.length - 1;
+    rightBar.slider.value = currentStateIndex;
+  }
 };

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -67,14 +67,13 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
     value: 0,
     minValue: 0,
     maxValue: 0,
-    change: newValue => {
+    change: newValue =>
       dispatch({
         type: 'JUMP_TO_STATE',
         actionId: storeLiftedState.stagedActionIds[newValue],
         index: newValue,
         dontUpdateTouchBarSlider: true,
-      });
-    },
+      }),
   }) : null;
   resetTouchBar();
 };

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -1,0 +1,87 @@
+import { remote } from 'electron';
+
+const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
+const currentWindow = remote.getCurrentWindow();
+
+let worker;
+let enableXHRInspect = false;
+const leftBar = {
+  reload: null,
+  enableXHRInspect: null,
+};
+
+let sliderEnabled;
+let storeLiftedState;
+const rightBar = {
+  slider: null,
+};
+
+const resetTouchBar = () => {
+  const touchBar = [
+    ...Object.keys(leftBar).filter(key => !!leftBar[key]).map(key => leftBar[key]),
+    ...Object.keys(rightBar).filter(key => !!rightBar[key]).map(key => rightBar[key]),
+  ];
+  currentWindow.setTouchBar(touchBar);
+};
+
+const invokeDevMenuMethod = ({ name, args }) =>
+  worker.postMessage({ method: 'invokeDevMenuMethod', name, args });
+
+export const setAvailableDevMenuMethods = (list, wkr) => {
+  if (process.platform !== 'darwin') return;
+
+  worker = wkr;
+
+  leftBar.reload = null;
+  leftBar.enableXHRInspect = null;
+  if (list.includes('reload')) {
+    leftBar.reload = new TouchBarButton({
+      label: 'Reload JS',
+      click: () => {
+        invokeDevMenuMethod({ name: 'reload' });
+      },
+    });
+  }
+
+  if (list.includes('enableXHRInspect')) {
+    leftBar.enableXHRInspect = new TouchBarButton({
+      label: 'Enable XHR Inspect',
+      click: () => {
+        enableXHRInspect = !enableXHRInspect;
+        leftBar.enableXHRInspect.label = enableXHRInspect ?
+          'Disable XHR Inspect' :
+          'Enable XHR Inspect';
+        invokeDevMenuMethod({ name: 'enableXHRInspect', args: [enableXHRInspect] });
+      },
+    });
+  }
+
+  resetTouchBar();
+};
+
+export const setReduxDevToolsMethods = (enabled, dispatch) => {
+  if (process.platform !== 'darwin') return;
+  if (enabled && sliderEnabled) return;
+  sliderEnabled = enabled;
+  leftBar.slider = enabled ? new TouchBarSlider({
+    value: 0,
+    minValue: 0,
+    maxValue: 0,
+    change: newValue => {
+      dispatch({
+        type: 'JUMP_TO_STATE',
+        actionId: storeLiftedState.stagedActionIds[newValue],
+        index: newValue,
+        dontUpdateTouchBarSlider: true,
+      });
+    },
+  }) : null;
+  resetTouchBar();
+};
+
+export const updateSliderContent = liftedState => {
+  storeLiftedState = liftedState;
+  const { currentStateIndex, computedStates } = liftedState;
+  leftBar.slider.maxValue = computedStates.length - 1;
+  leftBar.slider.value = currentStateIndex;
+};

--- a/app/middlewares/touchBarBuilder.js
+++ b/app/middlewares/touchBarBuilder.js
@@ -6,7 +6,7 @@ const currentWindow = remote.getCurrentWindow();
 let worker;
 const leftBar = {
   reload: null,
-  enableXHRInspect: null,
+  enableNetworkInspect: null,
 };
 
 let sliderEnabled;
@@ -37,7 +37,7 @@ export const setAvailableDevMenuMethods = (list, wkr) => {
   worker = wkr;
 
   leftBar.reload = null;
-  leftBar.enableXHRInspect = null;
+  leftBar.enableNetworkInspect = null;
   if (list.includes('reload')) {
     leftBar.reload = new TouchBarButton({
       label: 'Reload JS',
@@ -47,16 +47,19 @@ export const setAvailableDevMenuMethods = (list, wkr) => {
     });
   }
 
-  if (list.includes('enableXHRInspect')) {
-    const disabled = () => localStorage.enableXHRInspect === 'disabled';
-    const getLabel = () => (disabled() ? 'Disable XHR Inspect' : 'Enable XHR Inspect');
+  if (list.includes('enableNetworkInspect')) {
+    const disabled = () => localStorage.enableNetworkInspect === 'disabled';
+    const getLabel = () => (disabled() ? 'Disable Network Inspect' : 'Enable Network Inspect');
     const toggle = () => (disabled() ? 'enabled' : 'disabled');
-    leftBar.enableXHRInspect = new TouchBarButton({
+    leftBar.enableNetworkInspect = new TouchBarButton({
       label: getLabel(),
       click: () => {
-        localStorage.enableXHRInspect = toggle();
-        leftBar.enableXHRInspect.label = getLabel();
-        invokeDevMenuMethod({ name: 'enableXHRInspect', args: [localStorage.enableXHRInspect] });
+        localStorage.enableNetworkInspect = toggle();
+        leftBar.enableNetworkInspect.label = getLabel();
+        invokeDevMenuMethod({
+          name: 'enableNetworkInspect',
+          args: [localStorage.enableNetworkInspect],
+        });
       },
     });
   }

--- a/app/worker/devMenu.js
+++ b/app/worker/devMenu.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-underscore-dangle */
+
+// Avoid warning of use `window.require` on dev mode
+const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolve =>
+  setTimeout(() => {
+    // It's replaced console.warn of react-native
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      if (args[0] && args[0].indexOf(`Requiring module '${moduleName}' by name`) >= -1) return;
+      return originalWarn(...args);
+    };
+    resolve(() => { console.warn = originalWarn; });
+  })
+);
+
+const toggleXHRInspect = enabled => {
+  if (!enabled && window.__XHR_INSPECT__) {
+    window.XMLHttpRequest = window.__XHR_INSPECT__.XMLHttpRequest;
+    window.FormData = window.__XHR_INSPECT__.FormData;
+    delete window.__XHR_INSPECT__;
+    return;
+  }
+  if (!enabled) return;
+  window.__XHR_INSPECT__ = {
+    XMLHttpRequest: window.XMLHttpRequest,
+    FormData: window.FormData,
+  };
+  window.XMLHttpRequest = window.originalXMLHttpRequest ?
+    window.originalXMLHttpRequest :
+    window.XMLHttpRequest;
+  window.FormData = window.originalFormData ?
+    window.originalFormData :
+    window.FormData;
+};
+
+export const checkAvailableDevMenuMethods = async (enableXHRInspect = false) => {
+  const done = await avoidWarnForRequire();
+  const { DevMenu } = window.require('NativeModules');
+  done();
+
+  let result = ['enableXHRInspect'];
+  window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__ = {
+    enableXHRInspect: toggleXHRInspect,
+  };
+  if (DevMenu && DevMenu.reload) {
+    window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__.reload = DevMenu.reload;
+    result = ['reload', ...result];
+  }
+
+  toggleXHRInspect(enableXHRInspect);
+  postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
+};
+
+export const invokeDevMenuMethod = (name, args = []) => {
+  const method = window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__[name];
+  if (method) method(...args);
+};

--- a/app/worker/devMenu.js
+++ b/app/worker/devMenu.js
@@ -6,7 +6,7 @@ const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolv
     // It's replaced console.warn of react-native
     const originalWarn = console.warn;
     console.warn = (...args) => {
-      if (args[0] && args[0].indexOf(`Requiring module '${moduleName}' by name`) >= -1) return;
+      if (args[0] && args[0].indexOf(`Requiring module '${moduleName}' by name`) > -1) return;
       return originalWarn(...args);
     };
     resolve(() => { console.warn = originalWarn; });

--- a/app/worker/devMenu.js
+++ b/app/worker/devMenu.js
@@ -13,15 +13,15 @@ const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolv
   })
 );
 
-const toggleXHRInspect = enabled => {
-  if (!enabled && window.__XHR_INSPECT__) {
-    window.XMLHttpRequest = window.__XHR_INSPECT__.XMLHttpRequest;
-    window.FormData = window.__XHR_INSPECT__.FormData;
-    delete window.__XHR_INSPECT__;
+const toggleNetworkInspect = enabled => {
+  if (!enabled && window.__Network_INSPECT__) {
+    window.XMLHttpRequest = window.__Network_INSPECT__.XMLHttpRequest;
+    window.FormData = window.__Network_INSPECT__.FormData;
+    delete window.__Network_INSPECT__;
     return;
   }
   if (!enabled) return;
-  window.__XHR_INSPECT__ = {
+  window.__Network_INSPECT__ = {
     XMLHttpRequest: window.XMLHttpRequest,
     FormData: window.FormData,
   };
@@ -33,21 +33,21 @@ const toggleXHRInspect = enabled => {
     window.FormData;
 };
 
-export const checkAvailableDevMenuMethods = async (enableXHRInspect = false) => {
+export const checkAvailableDevMenuMethods = async (enableNetworkInspect = false) => {
   const done = await avoidWarnForRequire();
   const { DevMenu } = window.require('NativeModules');
   done();
 
-  let result = ['enableXHRInspect'];
+  let result = ['enableNetworkInspect'];
   window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__ = {
-    enableXHRInspect: toggleXHRInspect,
+    enableNetworkInspect: toggleNetworkInspect,
   };
   if (DevMenu && DevMenu.reload) {
     window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__.reload = DevMenu.reload;
     result = ['reload', ...result];
   }
 
-  toggleXHRInspect(enableXHRInspect);
+  toggleNetworkInspect(enableNetworkInspect);
   postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
 };
 

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -49,7 +49,7 @@ const messageHandlers = {
       self.__RND_INTERVAL__ = setInterval(function(){}, 100); // eslint-disable-line
     }
 
-    checkAvailableDevMenuMethods(message.enableXHRInspect);
+    checkAvailableDevMenuMethods(message.enableNetworkInspect);
   },
 };
 

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -78,6 +78,11 @@ const checkAvailableDevMenuMethods = async () => {
   postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
 };
 
+const invokeDevMenuMethod = (name, args = []) => {
+  const method = window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__[name];
+  if (method) method(...args);
+};
+
 const messageHandlers = {
   executeApplicationScript(message, sendReply) {
     Object.keys(message.inject).forEach(key => {
@@ -106,6 +111,11 @@ addEventListener('message', message => {
   // handle redux message
   if (object.method === 'emitReduxMessage') {
     return true;
+  }
+
+  if (object.method === 'invokeDevMenuMethod') {
+    invokeDevMenuMethod(object.name, object.args);
+    return false;
   }
 
   const sendReply = (result, error) => {

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -29,6 +29,55 @@ self.devToolsExtension = devTools.default;
 self.__REDUX_DEVTOOLS_EXTENSION__ = devTools.default;
 self.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = devTools.composeWithDevTools;
 
+const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolve =>
+  setTimeout(() => {
+    // It's replaced console.warn of react-native
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      if (args[0] && args[0].indexOf(`Requiring module '${moduleName}' by name`) >= -1) return;
+      return originalWarn(...args);
+    };
+    resolve(() => { console.warn = originalWarn; });
+  })
+);
+
+const XHRInspect = enabled => {
+  if (!enabled && window.__XHR_INSPECT__) {
+    window.XMLHttpRequest = window.__XHR_INSPECT__.XMLHttpRequest;
+    window.FormData = window.__XHR_INSPECT__.FormData;
+    delete window.__XHR_INSPECT__;
+    return;
+  }
+  if (!enabled) return;
+  window.__XHR_INSPECT__ = {
+    XMLHttpRequest: window.XMLHttpRequest,
+    FormData: window.FormData,
+  };
+  window.XMLHttpRequest = window.originalXMLHttpRequest ?
+    window.originalXMLHttpRequest :
+    window.XMLHttpRequest;
+  window.FormData = window.originalFormData ?
+    window.originalFormData :
+    window.FormData;
+};
+
+const checkAvailableDevMenuMethods = async () => {
+  const done = await avoidWarnForRequire();
+  const { DevMenu } = window.require('NativeModules');
+  done();
+
+  let result = ['enableXHRInspect'];
+  window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__ = {
+    enableXHRInspect: XHRInspect,
+  };
+  if (DevMenu && DevMenu.reload) {
+    window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__.reload = DevMenu.reload;
+    result = ['reload', ...result];
+  }
+
+  postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
+};
+
 const messageHandlers = {
   executeApplicationScript(message, sendReply) {
     Object.keys(message.inject).forEach(key => {
@@ -46,6 +95,8 @@ const messageHandlers = {
     if (!self.__RND_INTERVAL__) {
       self.__RND_INTERVAL__ = setInterval(function(){}, 100); // eslint-disable-line
     }
+
+    checkAvailableDevMenuMethods();
   },
 };
 

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -41,7 +41,7 @@ const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolv
   })
 );
 
-const XHRInspect = enabled => {
+const toggleXHRInspect = enabled => {
   if (!enabled && window.__XHR_INSPECT__) {
     window.XMLHttpRequest = window.__XHR_INSPECT__.XMLHttpRequest;
     window.FormData = window.__XHR_INSPECT__.FormData;
@@ -61,19 +61,21 @@ const XHRInspect = enabled => {
     window.FormData;
 };
 
-const checkAvailableDevMenuMethods = async () => {
+const checkAvailableDevMenuMethods = async (enableXHRInspect) => {
   const done = await avoidWarnForRequire();
   const { DevMenu } = window.require('NativeModules');
   done();
 
   let result = ['enableXHRInspect'];
   window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__ = {
-    enableXHRInspect: XHRInspect,
+    enableXHRInspect: toggleXHRInspect,
   };
   if (DevMenu && DevMenu.reload) {
     window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__.reload = DevMenu.reload;
     result = ['reload', ...result];
   }
+
+  toggleXHRInspect(enableXHRInspect);
 
   postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
 };
@@ -101,7 +103,7 @@ const messageHandlers = {
       self.__RND_INTERVAL__ = setInterval(function(){}, 100); // eslint-disable-line
     }
 
-    checkAvailableDevMenuMethods();
+    checkAvailableDevMenuMethods(message.enableXHRInspect);
   },
 };
 

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -10,12 +10,14 @@
 
 // Edit from https://github.com/facebook/react-native/blob/master/local-cli/server/util/debuggerWorker.js
 
-// NOTE: WebWorker not have `global`
+/* eslint-disable no-underscore-dangle */
+import { checkAvailableDevMenuMethods, invokeDevMenuMethod } from './devMenu';
+
+// WebWorker not have `global`
 self.global = self;
+
 // redux store enhancer
 const devTools = require('./reduxAPI');
-
-/* eslint-disable no-underscore-dangle */
 
 self.__REMOTEDEV__ = require('./remotedev');
 
@@ -28,62 +30,6 @@ self.reduxNativeDevToolsCompose = devTools.composeWithDevTools;
 self.devToolsExtension = devTools.default;
 self.__REDUX_DEVTOOLS_EXTENSION__ = devTools.default;
 self.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = devTools.composeWithDevTools;
-
-const avoidWarnForRequire = (moduleName = 'NativeModules') => new Promise(resolve =>
-  setTimeout(() => {
-    // It's replaced console.warn of react-native
-    const originalWarn = console.warn;
-    console.warn = (...args) => {
-      if (args[0] && args[0].indexOf(`Requiring module '${moduleName}' by name`) >= -1) return;
-      return originalWarn(...args);
-    };
-    resolve(() => { console.warn = originalWarn; });
-  })
-);
-
-const toggleXHRInspect = enabled => {
-  if (!enabled && window.__XHR_INSPECT__) {
-    window.XMLHttpRequest = window.__XHR_INSPECT__.XMLHttpRequest;
-    window.FormData = window.__XHR_INSPECT__.FormData;
-    delete window.__XHR_INSPECT__;
-    return;
-  }
-  if (!enabled) return;
-  window.__XHR_INSPECT__ = {
-    XMLHttpRequest: window.XMLHttpRequest,
-    FormData: window.FormData,
-  };
-  window.XMLHttpRequest = window.originalXMLHttpRequest ?
-    window.originalXMLHttpRequest :
-    window.XMLHttpRequest;
-  window.FormData = window.originalFormData ?
-    window.originalFormData :
-    window.FormData;
-};
-
-const checkAvailableDevMenuMethods = async (enableXHRInspect) => {
-  const done = await avoidWarnForRequire();
-  const { DevMenu } = window.require('NativeModules');
-  done();
-
-  let result = ['enableXHRInspect'];
-  window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__ = {
-    enableXHRInspect: toggleXHRInspect,
-  };
-  if (DevMenu && DevMenu.reload) {
-    window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__.reload = DevMenu.reload;
-    result = ['reload', ...result];
-  }
-
-  toggleXHRInspect(enableXHRInspect);
-
-  postMessage({ __AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__: result });
-};
-
-const invokeDevMenuMethod = (name, args = []) => {
-  const method = window.__AVAILABLE_METHODS_CAN_CALL_BY_RNDEBUGGER__[name];
-  if (method) method(...args);
-};
 
 const messageHandlers = {
   executeApplicationScript(message, sendReply) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "cross-env": "^3.1.3",
     "devtron": "^1.2.0",
-    "electron": "^1.6.0",
+    "electron": "^1.6.3",
     "electron-debug": "^1.0.0",
     "electron-devtools-installer": "^2.1.0",
     "electron-packager": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,9 +1674,9 @@ electron-packager@^8.2.0:
     sanitize-filename "^1.6.0"
     semver "^5.3.0"
 
-electron@^1.6.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.1.tgz#aa426e83bfb5919c3a492297eff368b67e66f1ae"
+electron@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.3.tgz#95fc62899e50838563fa768baa2011ea860d04b1"
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
@@ -5040,7 +5040,7 @@ sumchecker@^2.0.1:
   dependencies:
     debug "^2.2.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5053,12 +5053,6 @@ supports-color@^0.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  dependencies:
-    has-flag "^1.0.0"
 
 symbol-observable@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
Related to #18 but not added fully:

<img width="1096" alt="2017-03-10 5 14 57" src="https://cloud.githubusercontent.com/assets/3001525/23789309/466807e2-05b5-11e7-90d0-b203060ca898.png">

These are maybe to be used frequently:

* Invoke `Reload JS`  by dev menu of RN (Currently for iOS / [macOS](https://github.com/ptmt/react-native-macos))
* Enable / Disable Network Inspect
* The Redux slider
  - [x] Add ~~replay~~ / prev / next features
  - ~~[ ] Current action (Need to fixed the label size)~~
  - ~~[ ] Maybe make as a [popover](https://github.com/electron/electron/blob/master/docs/api/touch-bar-popover.md)?~~

Other suggestions are welcome.