### PR TITLE
Use adbkit instead of current adb util

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,7 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './containers/App';
 import configureStore from './store/configureStore';
+import { client, tryADBReverse } from './utils/adb';
 
 if (process.platform === 'darwin') {
   // Reset TouchBar when reload the app
@@ -14,6 +15,11 @@ webFrame.setZoomFactor(1);
 webFrame.setZoomLevelLimits(1, 1);
 
 const store = configureStore();
+
+// Provide for user
+window.adb = client;
+window.adb.reverseAll = tryADBReverse;
+// TODO: provide adb function for reverse RN packager port
 
 render(
   <Provider store={store}>

--- a/app/utils/adb.js
+++ b/app/utils/adb.js
@@ -1,39 +1,10 @@
-import fs from 'fs';
-import path from 'path';
-import { exec } from 'child_process';
+import adb from 'adbkit';
 
-const androidHome = process.env.ANDROID_HOME || '';
-let adbPath = path.join(androidHome, '/platform-tools/adb');
-if (!fs.existsSync(adbPath)) {
-  adbPath = 'adb';
-}
+export const client = adb.createClient();
 
-const execAsync = (cmd, opts = {}) => new Promise((resolve, reject) =>
-  exec(cmd, opts, (err, result) => {
-    if (err) return reject(err);
-    resolve(result);
-  })
-);
-
-const getDevices = async () => {
-  const result = (await execAsync(`${adbPath} devices`, { encoding: 'utf-8' }))
-    .trim()
-    .split(/\r?\n/)
-    .map(line => {
-      const [id, keyword] = line.split('\t').filter(w => w !== '');
-      if (keyword === 'device') {
-        return id;
-      }
-      return null;
-    })
-    .filter(item => !!item);
-  return result;
-};
-
-const reverse = (device, port) =>
-  execAsync(`${adbPath} -s ${device} reverse tcp:${port} tcp:${port}`);
+const reverse = (device, port) => client.reverse(device, `tcp:${port}`, `tcp:${port}`);
 
 export const tryADBReverse = async port => {
-  const devices = await getDevices();
-  return Promise.all(devices.map(device => reverse(device, port)));
+  const devices = await client.listDevices().filter(device => device.type === 'device');
+  return Promise.all(devices.map(device => reverse(device.id, port)));
 };

--- a/dist/package.json
+++ b/dist/package.json
@@ -11,6 +11,7 @@
   "author": "Jhen <developer@jhen.me>",
   "license": "MIT",
   "dependencies": {
+    "adbkit": "^2.9.2",
     "electron-config": "^0.2.1",
     "react-devtools-core": "^2.1.3",
     "source-map-support": "^0.4.1"

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+adbkit-logcat@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz#01d7f9b0cef9093a30bcb3b007efff301508962f"
+
+adbkit-monkey@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz#f291be701a2efc567a63fc7aa6afcded31430be1"
+  dependencies:
+    async "~0.2.9"
+
+adbkit@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/adbkit/-/adbkit-2.9.2.tgz#22c29fef9e40d041f1c22b014d599c0a9f83106c"
+  dependencies:
+    adbkit-logcat "^1.1.0"
+    adbkit-monkey "~1.0.1"
+    bluebird "~2.9.24"
+    commander "^2.3.0"
+    debug "~2.6.3"
+    node-forge "^0.6.12"
+    split "~0.3.3"
+
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
@@ -14,6 +36,20 @@ array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
+async@~0.2.9:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+
+bluebird@~2.9.24:
+  version "2.9.34"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
+
+commander@^2.3.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 conf@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/conf/-/conf-0.11.2.tgz#879f479267600483e502583462ca4063fc9779b2"
@@ -22,6 +58,12 @@ conf@^0.11.1:
     env-paths "^0.3.0"
     mkdirp "^0.5.1"
     pkg-up "^1.0.0"
+
+debug@~2.6.3:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
+  dependencies:
+    ms "0.7.3"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -46,6 +88,10 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -63,6 +109,14 @@ mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+ms@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
+
+node-forge@^0.6.12:
+  version "0.6.49"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.49.tgz#f1ee95d5d74623938fe19d698aa5a26d54d2f60f"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -115,6 +169,16 @@ source-map-support@^0.4.1:
 source-map@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+split@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 ultron@~1.1.0:
   version "1.1.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "worker-loader": "^0.8.0"
   },
   "dependencies": {
+    "adbkit": "^2.9.2",
     "electron-config": "^0.2.1",
     "electron-context-menu": "^0.9.0",
     "electron-gh-releases": "^2.0.4",

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -1,14 +1,9 @@
 import fs from 'fs';
 import { join } from 'path';
 
-const babelConfig = JSON.parse(
-  fs.readFileSync(join(__dirname, '../.babelrc'), 'utf-8')
-);
+const babelConfig = JSON.parse(fs.readFileSync(join(__dirname, '../.babelrc'), 'utf-8'));
 // Webpack 2 have native import / export support
-babelConfig.presets = [
-  ['env', { targets: { node: 7.6 }, modules: false }],
-  'react',
-];
+babelConfig.presets = [['env', { targets: { node: 7.6 }, modules: false }], 'react'];
 babelConfig.babelrc = false;
 
 export default {
@@ -17,27 +12,32 @@ export default {
     filename: 'bundle.js',
     libraryTarget: 'commonjs2',
   },
-  plugins: [
-  ],
+  plugins: [],
   resolve: {
     extensions: ['.js'],
   },
   module: {
-    rules: [{
-      test: /\.js$/,
-      use: [{
-        loader: 'babel-loader',
-        query: babelConfig,
-      }],
-      exclude: /node_modules/,
-    }],
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            query: babelConfig,
+          },
+        ],
+        exclude: /node_modules/,
+      },
+    ],
   },
   externals: [
     'react-devtools-core/standalone',
     // just avoid warning.
     // this is not really used from ws. (it used fallback)
-    'utf-8-validate', 'bufferutil',
+    'utf-8-validate',
+    'bufferutil',
     // https://github.com/sindresorhus/conf/blob/master/index.js#L13
     'electron-config',
+    'adbkit',
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,28 @@ acorn@^5.0.0, acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
+adbkit-logcat@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz#01d7f9b0cef9093a30bcb3b007efff301508962f"
+
+adbkit-monkey@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz#f291be701a2efc567a63fc7aa6afcded31430be1"
+  dependencies:
+    async "~0.2.9"
+
+adbkit@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/adbkit/-/adbkit-2.9.2.tgz#22c29fef9e40d041f1c22b014d599c0a9f83106c"
+  dependencies:
+    adbkit-logcat "^1.1.0"
+    adbkit-monkey "~1.0.1"
+    bluebird "~2.9.24"
+    commander "^2.3.0"
+    debug "~2.6.3"
+    node-forge "^0.6.12"
+    split "~0.3.3"
+
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -256,6 +278,10 @@ async@^2.0.0, async@^2.1.2:
   resolved "https://registry.yarnpkg.com/async/-/async-2.3.0.tgz#1013d1051047dd320fe24e494d5c66ecaf6147d9"
   dependencies:
     lodash "^4.14.0"
+
+async@~0.2.9:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1144,6 +1170,10 @@ bluebird@^3.1.1, bluebird@^3.4.7:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
+bluebird@~2.9.24:
+  version "2.9.34"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
@@ -1458,7 +1488,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.9.0:
+commander@2.9.0, commander@^2.3.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1816,7 +1846,7 @@ debug@2.6.4:
   dependencies:
     ms "0.7.3"
 
-debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.1:
+debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.1, debug@~2.6.3:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
   dependencies:
@@ -4019,6 +4049,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-forge@^0.6.12:
+  version "0.6.49"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.49.tgz#f1ee95d5d74623938fe19d698aa5a26d54d2f60f"
+
 node-libs-browser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.0.0.tgz#a3a59ec97024985b46e958379646f96c4b616646"
@@ -5510,6 +5544,12 @@ speedometer@~0.1.2:
 split@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
+  dependencies:
+    through "2"
+
+split@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
   dependencies:
     through "2"
 


### PR DESCRIPTION
Currently we have [adb util](https://github.com/jhen0409/react-native-debugger/blob/3117b49865b60f19baab3444a8c7afd9d9beb2e3/app/utils/adb.js) used for reverse port of `react-devtools` for Android, so we never need to run `adb reverse tcp: 8097 tcp: 8097`, but it can't work if `adb` bin not found, use [`adbkit`](https://github.com/openstf/adbkit) instead will be better. 

Also export `window.adb` as an extra useful tool, we can use it in the console.