### PR TITLE
Fix SyntaxError: Block-scoped declarations

### DIFF
--- a/npm-package/bin/rndebugger-open.js
+++ b/npm-package/bin/rndebugger-open.js
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
 
+'use strict'
 const defaultPort = 8081;
 const expoDefaultPort = 19001;
 

--- a/npm-package/bin/rndebugger-open.js
+++ b/npm-package/bin/rndebugger-open.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-'use strict'
+'use strict';
 const defaultPort = 8081;
 const expoDefaultPort = 19001;
 


### PR DESCRIPTION
Add 'use strict' to fix:

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:54:16)
    at Module._compile (module.js:375:25)
    at Object.Module._extensions..js (module.js:406:10)
    at Module.load (module.js:345:32)
    at Function.Module._load (module.js:302:12)
    at Function.Module.runMain (module.js:431:10)
    at startup (node.js:141:18)
    at node.js:977:3
