### PR TITLE
Use yarn instead of npm for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ osx_image: xcode8.3
 env:
   - NODE_VERSION="7"
 cache:
+  yarn: true
   directories:
     - node_modules
 script: ./scripts/travis-build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,17 +6,18 @@ environment:
   nodejs_version: '7'
 
 cache:
+  - "%LOCALAPPDATA%/Yarn"
   - node_modules -> package.json
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm
-  - npm install
-  - cd npm-package && npm install && cd ..
+  - yarn
+  - cd dist && yarn && cd ..
+  - cd npm-package && yarn && cd ..
 
 test_script:
   - node --version
-  - npm --version
-  - npm run lint
-  - npm run build
-  - npm test
+  - yarn --version
+  - yarn lint
+  - yarn build
+  - yarn test

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,25 +1,32 @@
 # Contributing
 
-## Clone this repo & install dependencies
+## Fork this repo & install dependencies
+
+We're recommended use yarn because we keep the dependencies lock of yarn.
 
 ```bash
-# Or fork
-$ git clone https://github.com/jhen0409/react-native-debugger
-$ cd react-native-debugger
+# In react-native-debugger directory
+$ yarn
+$ cd dist && yarn && cd ..
+$ cd npm-package && yarn && cd ..
 ```
+
+If you want to debug the [NPM package](../npm-package), just run `yarn link <the package path>` on your React Native project.
 
 ## Run on development mode
 
 ```bash
-$ npm run dev:webpack  # Then open the another terminal tab
-$ npm run dev:electron
+$ yarn dev:webpack  # Then open the another terminal tab
+$ yarn dev:electron
 ```
+
+Please ensure the `React Native Debugger` production app is closed.
 
 ## Run on production mode
 
 ```bash
-$ npm run build
-$ npm start
+$ yarn build
+$ yarn start
 ```
 
 ## Run test
@@ -27,19 +34,19 @@ $ npm start
 Run lint and test, currently we just wrote E2E test for RNDebugger.
 
 ```bash
-$ npm run lint
-$ npm test
+$ yarn lint
+$ yarn test
 ```
 
-you need to closes all React Native packager (or just make sure `8081` or `8088` port not listening) when running the test.
+You need to closes all React Native packager (or just make sure `8081` or `8088` port not listening) when running the test.
 
 ## Packaging app
 
 ```bash
-$ npm run pack-macos
-$ npm run pack-linux
-$ npm run pack-windows
-$ npm run pack # all
+$ yarn run pack-macos
+$ yarn run pack-linux
+$ yarn run pack-windows
+$ yarn run pack # all
 ```
 
 If you want to build binaries yourself, please remove [../electron/update.js](electron/update.js) (and [../electon/main.js usage](electon/main.js)), `osx-sign` in [../scripts/package-macos.sh](scripts/package-macos.sh).

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -14,8 +14,9 @@ fi
 node --version
 npm --version
 
-npm install
-cd npm-package && npm install && cd ..
-npm run lint
-npm run build
-npm test
+yarn
+cd npm-package && yarn && cd ..
+cd dist && yarn && cd ..
+yarn lint
+yarn build
+yarn test

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -5,6 +5,9 @@ source /tmp/.nvm/nvm.sh
 nvm install "$NODE_VERSION"
 nvm use --delete-prefix "$NODE_VERSION"
 
+# osx_image target haven't built-in yarn
+npm install -g yarn
+
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   export DISPLAY=:99.0
   sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Just keep using yarn.lock on CI.

We don't upgrade dependencies of babili-webpack-plugin for the time being because it produces some bugs.