### PR TITLE
Handle fatal errors thrown by the Chrome debugger (from RN upstream)

### DIFF
--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -51,7 +51,7 @@ const messageHandlers = {
     try {
       importScripts(message.url);
     } catch (err) {
-      error = JSON.stringify(err);
+      error = err.message;
     }
     sendReply(null /* result */, error);
     if (!error) {
@@ -84,12 +84,17 @@ addEventListener('message', message => {
   } else {
     // Other methods get called on the bridge
     let returnValue = [[], [], [], 0];
+    let error;
     try {
       if (typeof __fbBatchedBridge === 'object') {
         returnValue = __fbBatchedBridge[object.method].apply(null, object.arguments);
+      } else {
+        error = 'Failed to call function, __fbBatchedBridge is undefined';
       }
+    } catch (err) {
+      error = err.message;
     } finally {
-      sendReply(JSON.stringify(returnValue));
+      sendReply(JSON.stringify(returnValue), error);
     }
   }
 });


### PR DESCRIPTION
Update from upstream: https://github.com/facebook/react-native/commit/2e4284215c5482f3e0f4b9fba0046661aa9cd992 (It will release as RN 0.47)

It doesn't break old versions of RN, currently the `error` just handle for Android (see [this commit](https://github.com/facebook/react-native/commit/bbd1e455f391aef6dc8dfbd934377bf90016e35d)). It will just print a JSON string on redbox, so this change will improve old versions for Android.