### PR TITLE
Use icon instead of text for macOS Touch Bar

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
       }
     ],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "import/no-extraneous-dependencies": ["error", { "optionalDependencies": true }]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 os:
   - linux
   - osx
-osx_image: xcode8.3
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+
 env:
   - NODE_VERSION="7"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
   include:
     - os: osx
       osx_image: xcode8.3
+    - os: osx
+      osx_image: xcode6.4
 
 env:
   - NODE_VERSION="7"

--- a/app/containers/ReactInspector.js
+++ b/app/containers/ReactInspector.js
@@ -3,9 +3,16 @@
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactServer from 'react-devtools-core/standalone';
 import { tryADBReverse } from '../utils/adb';
 
+let ReactServer;
+const getReactInspector = () => {
+  if (ReactServer) return ReactServer;
+  // eslint-disable-next-line
+  ReactServer = ReactServer || require('react-devtools-core/standalone');
+
+  return ReactServer;
+};
 const containerId = 'react-devtools-container';
 
 const styles = {
@@ -37,11 +44,11 @@ export default class ReactInspector extends Component {
   };
 
   static setDefaultThemeName(themeName) {
-    ReactServer.setDefaultThemeName(themeName === 'dark' ? 'ChromeDark' : 'ChromeDefault');
+    getReactInspector().setDefaultThemeName(themeName === 'dark' ? 'ChromeDark' : 'ChromeDefault');
   }
 
   static setProjectRoots(projectRoots) {
-    ReactServer.setProjectRoots(projectRoots);
+    getReactInspector().setProjectRoots(projectRoots);
   }
 
   componentDidMount() {
@@ -90,7 +97,8 @@ export default class ReactInspector extends Component {
   };
 
   startServer(port = this.listeningPort) {
-    return ReactServer.setBrowserName('RNDebugger DevTools')
+    return getReactInspector()
+      .setBrowserName('RNDebugger DevTools')
       .setStatusListener(status => {
         if (!this.loggedWarn && port === 8097 && status === 'Failed to start the server.') {
           console.warn(
@@ -116,7 +124,11 @@ export default class ReactInspector extends Component {
   render() {
     return (
       <div id={containerId} style={styles.container}>
-        <div id="waiting"><h2>{'Waiting for React to connect…'}</h2></div>
+        <div id="waiting">
+          <h2>
+            {'Waiting for React to connect…'}
+          </h2>
+        </div>
       </div>
     );
   }

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -1,7 +1,9 @@
 import { remote } from 'electron';
 import contextMenu from 'electron-context-menu';
+import namedImage from 'electron-named-image';
 import { item, n, toggleDevTools, separator } from '../../electron/menu/util';
 
+const { nativeImage } = remote;
 const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
 const currentWindow = remote.getCurrentWindow();
 
@@ -73,20 +75,30 @@ contextMenu({
       .concat(defaultContextMenuItems),
 });
 
+const icon = name => nativeImage.createFromBuffer(namedImage.getImageNamed(name));
+
 const setDevMenuMethodsForTouchBar = () => {
   if (process.platform !== 'darwin') return;
 
   leftBar = {
-    reload: availableMethods.includes('reload') &&
-      new TouchBarButton(item('Reload JS', n, devMenuMethods.reload)),
-    toggleElementInspector: availableMethods.includes('toggleElementInspector') &&
-      new TouchBarButton(item('Inspector', n, devMenuMethods.toggleElementInspector)),
+    reload:
+      availableMethods.includes('reload') &&
+      new TouchBarButton({
+        icon: icon('NSTouchBarRefreshTemplate'),
+        click: devMenuMethods.reload,
+      }),
+    toggleElementInspector:
+      availableMethods.includes('toggleElementInspector') &&
+      new TouchBarButton({
+        icon: icon('NSTouchBarQuickLookTemplate'),
+        click: devMenuMethods.toggleElementInspector,
+      }),
     // Default items
-    networkInspect: new TouchBarButton(
-      item('Network Inspect', n, devMenuMethods.networkInspect, {
-        backgroundColor: networkInspect.getHighlightColor(),
-      })
-    ),
+    networkInspect: new TouchBarButton({
+      icon: icon('NSTouchBarRecordStartTemplate'),
+      click: devMenuMethods.networkInspect,
+      backgroundColor: networkInspect.getHighlightColor(),
+    }),
   };
   setTouchBar();
 };
@@ -128,7 +140,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       },
     }),
     prev: new TouchBarButton({
-      label: 'Prev',
+      icon: icon('NSTouchBarGoBackTemplate'),
       click() {
         const nextIndex = storeLiftedState.currentStateIndex - 1;
         if (nextIndex >= 0) {
@@ -137,7 +149,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       },
     }),
     next: new TouchBarButton({
-      label: 'Next',
+      icon: icon('NSTouchBarGoForwardTemplate'),
       click() {
         const nextIndex = storeLiftedState.currentStateIndex + 1;
         if (nextIndex < storeLiftedState.computedStates.length) {

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -79,25 +79,38 @@ contextMenu({
 
 const icon = name => nativeImage.createFromBuffer(namedImage.getImageNamed(name));
 
+let namedImages;
+const initNamedImages = () => {
+  if (process.platform !== 'darwin' || namedImages) return;
+  namedImages = {
+    reload: icon('NSTouchBarRefreshTemplate'),
+    toggleElementInspector: icon('NSTouchBarQuickLookTemplate'),
+    networkInspect: icon('NSTouchBarRecordStartTemplate'),
+    prev: icon('NSTouchBarGoBackTemplate'),
+    next: icon('NSTouchBarGoForwardTemplate'),
+  };
+};
+
 const setDevMenuMethodsForTouchBar = () => {
   if (process.platform !== 'darwin') return;
+  initNamedImages();
 
   leftBar = {
     reload:
       availableMethods.includes('reload') &&
       new TouchBarButton({
-        icon: icon('NSTouchBarRefreshTemplate'),
+        icon: namedImages.reload,
         click: devMenuMethods.reload,
       }),
     toggleElementInspector:
       availableMethods.includes('toggleElementInspector') &&
       new TouchBarButton({
-        icon: icon('NSTouchBarQuickLookTemplate'),
+        icon: namedImages.toggleElementInspector,
         click: devMenuMethods.toggleElementInspector,
       }),
     // Default items
     networkInspect: new TouchBarButton({
-      icon: icon('NSTouchBarRecordStartTemplate'),
+      icon: namedImages.networkInspect,
       click: devMenuMethods.networkInspect,
       backgroundColor: networkInspect.getHighlightColor(),
     }),
@@ -117,6 +130,7 @@ export const setDevMenuMethods = (list, wkr) => {
 
 export const setReduxDevToolsMethods = (enabled, dispatch) => {
   if (process.platform !== 'darwin') return;
+  initNamedImages();
 
   // Already setup
   if (enabled && isSliderEnabled) return;
@@ -142,7 +156,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       },
     }),
     prev: new TouchBarButton({
-      icon: icon('NSTouchBarGoBackTemplate'),
+      icon: namedImages.prev,
       click() {
         const nextIndex = storeLiftedState.currentStateIndex - 1;
         if (nextIndex >= 0) {
@@ -151,7 +165,7 @@ export const setReduxDevToolsMethods = (enabled, dispatch) => {
       },
     }),
     next: new TouchBarButton({
-      icon: icon('NSTouchBarGoForwardTemplate'),
+      icon: namedImages.next,
       click() {
         const nextIndex = storeLiftedState.currentStateIndex + 1;
         if (nextIndex < storeLiftedState.computedStates.length) {

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -1,11 +1,12 @@
 import { remote } from 'electron';
 import contextMenu from 'electron-context-menu';
-import namedImage from 'electron-named-image';
 import { item, n, toggleDevTools, separator } from '../../electron/menu/util';
 
 const { nativeImage } = remote;
 const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
 const currentWindow = remote.getCurrentWindow();
+
+const namedImage = process.platform === 'darwin' ? require('electron-named-image') : {};
 
 let worker;
 let availableMethods = [];

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -6,6 +6,7 @@ const { nativeImage } = remote;
 const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
 const currentWindow = remote.getCurrentWindow();
 
+// eslint-disable-next-line import/no-unresolved
 const namedImage = process.platform === 'darwin' ? require('electron-named-image') : {};
 
 let worker;

--- a/dist/package.json
+++ b/dist/package.json
@@ -15,7 +15,7 @@
     "electron-store": "^1.1.0",
     "react-devtools-core": "^2.3.3"
   },
-  "optionalDependencies":{
+  "optionalDependencies": {
     "electron-named-image": "^1.0.0"
   }
 }

--- a/dist/package.json
+++ b/dist/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "adbkit": "^2.9.2",
+    "electron-named-image": "^1.0.0",
     "electron-store": "^1.1.0",
     "react-devtools-core": "^2.3.3"
   }

--- a/dist/package.json
+++ b/dist/package.json
@@ -16,6 +16,6 @@
     "react-devtools-core": "^2.3.3"
   },
   "optionalDependencies": {
-    "electron-named-image": "^1.0.1"
+    "electron-named-image": "^1.0.2"
   }
 }

--- a/dist/package.json
+++ b/dist/package.json
@@ -12,8 +12,10 @@
   "license": "MIT",
   "dependencies": {
     "adbkit": "^2.9.2",
-    "electron-named-image": "^1.0.0",
     "electron-store": "^1.1.0",
     "react-devtools-core": "^2.3.3"
+  },
+  "optionalDependencies":{
+    "electron-named-image": "^1.0.0"
   }
 }

--- a/dist/package.json
+++ b/dist/package.json
@@ -16,6 +16,6 @@
     "react-devtools-core": "^2.3.3"
   },
   "optionalDependencies": {
-    "electron-named-image": "^1.0.0"
+    "electron-named-image": "^1.0.1"
   }
 }

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -71,9 +71,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-electron-named-image@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.0.tgz#d0bfc6dd318e4b220e8f7a62ef638c0e847c0000"
+electron-named-image@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.1.tgz#d044c88eacd224ee3d042a12276806baa0c88c04"
   dependencies:
     nan "^2.6.2"
 

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -45,8 +45,8 @@ bluebird@~2.9.24:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
 
 commander@^2.3.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.10.0.tgz#e1f5d3245de246d1a5ca04702fa1ad1bd7e405fe"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
@@ -155,8 +155,8 @@ pkg-up@^2.0.0:
     find-up "^2.1.0"
 
 react-devtools-core@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.3.3.tgz#3a950e6f20f2c8e67d0419e428c8500e7d8bf347"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.4.0.tgz#8f261b2fcfb02ecef1f15e17d75ee1b521f02029"
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -71,9 +71,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-electron-named-image@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.1.tgz#d044c88eacd224ee3d042a12276806baa0c88c04"
+electron-named-image@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.2.tgz#8b49841169d8240500f5cabe4f07bcf6bceb5554"
   dependencies:
     nan "^2.6.2"
 

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -71,6 +71,12 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+electron-named-image@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.0.tgz#d0bfc6dd318e4b220e8f7a62ef638c0e847c0000"
+  dependencies:
+    nan "^2.6.2"
+
 electron-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-1.1.0.tgz#3a06fbdc8c64ca14163dea054470f7561a7906aa"
@@ -115,6 +121,10 @@ make-dir@^1.0.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+nan@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
 node-forge@^0.6.12:
   version "0.6.49"

--- a/docs/debugger-integration.md
+++ b/docs/debugger-integration.md
@@ -27,7 +27,7 @@ Other features (cross-platform):
 
 They are also in Touch Bar:
 
-<img width="1085" alt="touch-bar" src="https://cloud.githubusercontent.com/assets/3001525/25571883/38d4da3a-2e67-11e7-9386-f52bb62572b3.png">
+<img alt="touch-bar" src="https://user-images.githubusercontent.com/3001525/27730359-8565810a-5dbb-11e7-9052-9fd4feb72181.png">
 
 It have Redux slider on the right. (If you're using [`Redux API`](redux-devtools-integration.md))
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "ws": "^3.0.0"
   },
   "optionalDependencies": {
-    "electron-named-image": "^1.0.0"
+    "electron-named-image": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "adbkit": "^2.10.0",
     "electron-context-menu": "^0.9.1",
     "electron-gh-releases": "^2.0.4",
-    "electron-named-image": "^1.0.0",
     "electron-store": "^1.1.0",
     "get-port": "^3.1.0",
     "jsan": "^3.1.9",
@@ -85,5 +84,8 @@
     "remotedev-slider": "^1.1.3",
     "remotedev-utils": "^0.1.4",
     "ws": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "electron-named-image": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node-watch": "^0.5.5",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
-    "react-devtools-core": "^2.3.3",
+    "react-devtools-core": "^2.4.0",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",
     "redux": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "ws": "^3.0.0"
   },
   "optionalDependencies": {
-    "electron-named-image": "^1.0.1"
+    "electron-named-image": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The standalone app for React Native Debugger, with React DevTools / Redux DevTools",
   "main": "electron/main.js",
   "scripts": {
-    "prepack": "./scripts/prepackage.sh",
+    "prepack": "./scripts/prebuild.sh && npm run build",
     "pack-macos": "npm run prepack && ./scripts/package-macos.sh",
     "pack-linux": "npm run prepack && ./scripts/package-linux.sh",
     "pack-windows": "npm run prepack && ./scripts/package-windows.sh",
@@ -17,7 +17,8 @@
     "dev:webpack": "webpack-dev-server --config webpack/renderer.dev.babel.js",
     "dev:electron": "cross-env NODE_ENV=development electron -r babel-core/register -r ./electron/debug .",
     "lint": "eslint .",
-    "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js"
+    "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js",
+    "postinstall": "./scripts/prebuild.sh"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
     "electron-debug": "^1.2.0",
     "electron-devtools-installer": "^2.2.0",
     "electron-packager": "^8.7.1",
+    "electron-rebuild": "^1.5.11",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.0",
     "eslint-plugin-import": "^1.12.0",
@@ -64,6 +66,7 @@
     "adbkit": "^2.10.0",
     "electron-context-menu": "^0.9.1",
     "electron-gh-releases": "^2.0.4",
+    "electron-named-image": "^1.0.0",
     "electron-store": "^1.1.0",
     "get-port": "^3.1.0",
     "jsan": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "The standalone app for React Native Debugger, with React DevTools / Redux DevTools",
   "main": "electron/main.js",
   "scripts": {
-    "prepack": "./scripts/prebuild.sh && npm run build",
-    "pack-macos": "npm run prepack && ./scripts/package-macos.sh",
-    "pack-linux": "npm run prepack && ./scripts/package-linux.sh",
-    "pack-windows": "npm run prepack && ./scripts/package-windows.sh",
+    "pack-macos": "npm run build && ./scripts/package-macos.sh",
+    "pack-linux": "npm run build && ./scripts/package-linux.sh",
+    "pack-windows": "npm run build && ./scripts/package-windows.sh",
+    "prepack": "npm run build",
     "pack": "./scripts/package-macos.sh && ./scripts/package-linux.sh && ./scripts/package-windows.sh",
     "start": "cd dist && cross-env NODE_ENV=production electron ./",
     "build:main": "cross-env NODE_ENV=production webpack --config webpack/main.prod.babel.js --progress --profile --colors",
@@ -18,7 +18,7 @@
     "dev:electron": "cross-env NODE_ENV=development electron -r babel-core/register -r ./electron/debug .",
     "lint": "eslint .",
     "test": "mocha --compilers js:babel-core/register ./test/e2e/app.spec.js",
-    "postinstall": "./scripts/prebuild.sh"
+    "postinstall": "./scripts/postinstall.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -7,7 +7,7 @@ electron-packager dist/ \
   --platform linux \
   --arch x64 \
   --asar \
-  --prune \
+  --no-prune \
   --out release \
   --electron-version $(node -e "console.log(require('electron/package').version)") \
   --app-version $npm_package_version

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -7,7 +7,7 @@ electron-packager dist/ \
   --platform darwin \
   --arch x64 \
   --asar \
-  --prune \
+  --no-prune \
   --out release \
   --protocol-name "React Native Debugger" \
   --protocol "rndebugger" \

--- a/scripts/package-windows.sh
+++ b/scripts/package-windows.sh
@@ -7,7 +7,7 @@ electron-packager dist/ \
   --platform win32 \
   --arch ia32 \
   --asar \
-  --prune \
+  --no-prune \
   --out release \
   --electron-version $(node -e "console.log(require('electron/package').version)") \
   --app-version $npm_package_version \

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function rebuild {
+  # electron-named-image is only for macOS
+  electron-rebuild -f -w electron-named-image
+}
+
+rebuild
+cd dist
+yarn
+rebuild
+electron-rebuild -f -w electron-named-image
+rm -rf node_modules/*/{example,examples,test,tests,*.md,*.markdown,CHANGELOG*,.*,Makefile}
+cd -
+
+./scripts/patch-react-devtools.sh

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -5,7 +5,7 @@ platform=`uname`
 function rebuild {
   # electron-named-image is only for macOS
   if [[ "$platform" == 'Darwin' ]]; then
-    electron-rebuild -f -w electron-named-image
+    electron-rebuild -f -w electron-named-image -t prod,optional
   fi
 }
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 
+platform=`uname`
+
 function rebuild {
   # electron-named-image is only for macOS
-  electron-rebuild -f -w electron-named-image
+  if [[ "$platform" == 'Darwin' ]]; then
+    electron-rebuild -f -w electron-named-image
+  fi
 }
 
 rebuild
 cd dist
 yarn
 rebuild
-electron-rebuild -f -w electron-named-image
 rm -rf node_modules/*/{example,examples,test,tests,*.md,*.markdown,CHANGELOG*,.*,Makefile}
 cd -
 

--- a/scripts/prepackage.sh
+++ b/scripts/prepackage.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-npm run build
-cd dist
-npm i
-rm -rf node_modules/*/{example,examples,test,tests,*.md,*.markdown,CHANGELOG*,.*,Makefile}
-cd -
-
-./scripts/patch-react-devtools.sh

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -19,7 +19,6 @@ npm --version
 
 yarn
 cd npm-package && yarn && cd ..
-cd dist && yarn && cd ..
 yarn lint
 yarn build
 yarn test

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -39,5 +39,6 @@ export default {
     // https://github.com/sindresorhus/conf/blob/master/index.js#L13
     'electron-store',
     'adbkit',
+    'electron-named-image',
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,9 +2148,9 @@ electron-localshortcut@^2.0.0:
     debug "^2.6.8"
     electron-is-accelerator "^0.1.0"
 
-electron-named-image@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.1.tgz#d044c88eacd224ee3d042a12276806baa0c88c04"
+electron-named-image@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.2.tgz#8b49841169d8240500f5cabe4f07bcf6bceb5554"
   dependencies:
     nan "^2.6.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4869,9 +4869,9 @@ react-base16-styling@^0.5.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-devtools-core@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.3.3.tgz#3a950e6f20f2c8e67d0419e428c8500e7d8bf347"
+react-devtools-core@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.4.0.tgz#8f261b2fcfb02ecef1f15e17d75ee1b521f02029"
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,9 +2148,9 @@ electron-localshortcut@^2.0.0:
     debug "^2.6.8"
     electron-is-accelerator "^0.1.0"
 
-electron-named-image@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.0.tgz#d0bfc6dd318e4b220e8f7a62ef638c0e847c0000"
+electron-named-image@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.1.tgz#d044c88eacd224ee3d042a12276806baa0c88c04"
   dependencies:
     nan "^2.6.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,10 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+any-promise@^1.0.0, any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -1448,6 +1452,10 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-spinners@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.0.0.tgz#ef987ed3d48391ac3dab9180b406a742180d6e6a"
+
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
@@ -1494,6 +1502,10 @@ color-space@^1.14.3:
 colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+
+colors@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -1848,7 +1860,7 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.8, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.1, debug@^2.6.8, debug@~2.6.3:
+debug@2.6.8, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.5.1, debug@^2.6.1, debug@^2.6.3, debug@^2.6.8, debug@~2.6.3:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2136,6 +2148,12 @@ electron-localshortcut@^2.0.0:
     debug "^2.6.8"
     electron-is-accelerator "^0.1.0"
 
+electron-named-image@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-named-image/-/electron-named-image-1.0.0.tgz#d0bfc6dd318e4b220e8f7a62ef638c0e847c0000"
+  dependencies:
+    nan "^2.6.2"
+
 electron-osx-sign@^0.4.1:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.6.tgz#2398e2d7cab5c1d8c3eeabb1cd490376528ec39a"
@@ -2166,6 +2184,20 @@ electron-packager@^8.7.1:
     run-series "^1.1.1"
     sanitize-filename "^1.6.0"
     semver "^5.3.0"
+
+electron-rebuild@^1.5.11:
+  version "1.5.11"
+  resolved "https://registry.yarnpkg.com/electron-rebuild/-/electron-rebuild-1.5.11.tgz#6ea660deb546a516e7efaa81cd5985d5664f245c"
+  dependencies:
+    colors "^1.1.2"
+    debug "^2.6.3"
+    fs-promise "^2.0.2"
+    node-abi "^2.0.0"
+    node-gyp "^3.6.0"
+    ora "^1.2.0"
+    rimraf "^2.6.1"
+    spawn-rx "^2.0.10"
+    yargs "^7.0.2"
 
 electron-store@^1.1.0:
   version "1.1.0"
@@ -2785,6 +2817,15 @@ fs-extra@^3.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
     universalify "^0.1.0"
+
+fs-promise@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
+  dependencies:
+    any-promise "^1.3.0"
+    fs-extra "^2.0.0"
+    mz "^2.6.0"
+    thenify-all "^1.6.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3776,6 +3817,10 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -3855,6 +3900,12 @@ lodash@4.2.1:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -4116,7 +4167,15 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+mz@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.6.0.tgz#c8b8521d958df0a4f2768025db69c719ee4ef1ce"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
+nan@^2.3.0, nan@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
@@ -4136,6 +4195,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+node-abi@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.0.3.tgz#0ca67e5e667b8e1343549ca17153a815d0bbfdaa"
+
 node-fetch@^1.0.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
@@ -4150,6 +4213,24 @@ node-forge@0.6.33:
 node-forge@^0.6.12:
   version "0.6.49"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.49.tgz#f1ee95d5d74623938fe19d698aa5a26d54d2f60f"
+
+node-gyp@^3.6.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
+  dependencies:
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "2"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^2.0.0"
+    which "1"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -4208,7 +4289,7 @@ nomnom@~1.6.2:
     colors "0.5.x"
     underscore "~1.4.4"
 
-nopt@^3.0.1:
+"nopt@2 || 3", nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -4246,7 +4327,7 @@ npm-install-package@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/npm-install-package/-/npm-install-package-2.1.0.tgz#d7efe3cfcd7ab00614b896ea53119dc9ab259125"
 
-npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
   dependencies:
@@ -4374,6 +4455,15 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-1.3.0.tgz#80078dd2b92a934af66a3ad72a5b910694ede51a"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.0.0"
+    log-symbols "^1.0.2"
+
 original@>=0.0.5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b"
@@ -4398,7 +4488,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@^0.1.4:
+osenv@0, osenv@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   dependencies:
@@ -5221,7 +5311,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.45.0, request@^2.65.0, request@^2.79.0, request@^2.81.0, request@~2.81.0:
+request@2, request@^2.45.0, request@^2.65.0, request@^2.79.0, request@^2.81.0, request@~2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5360,6 +5450,12 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+rxjs@^5.1.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.1.tgz#b62f757f279445d265a18a58fb0a70dc90e91626"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -5410,7 +5506,7 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.6.33"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -5611,6 +5707,14 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, sour
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+spawn-rx@^2.0.10:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/spawn-rx/-/spawn-rx-2.0.11.tgz#65451ad65662801daea75549832a782de0048dbf"
+  dependencies:
+    debug "^2.5.1"
+    lodash.assign "^4.2.0"
+    rxjs "^5.1.1"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -5807,7 +5911,7 @@ sumchecker@^2.0.1:
   dependencies:
     debug "^2.2.0"
 
-supports-color@3.1.2, supports-color@^3.1.1, supports-color@^3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5821,7 +5925,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@~3.2.3:
+supports-color@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -5831,7 +5935,7 @@ symbol-observable@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.3:
+symbol-observable@^1.0.1, symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -5872,7 +5976,7 @@ tar-stream@^1.5.0:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
-tar@^2.2.1:
+tar@^2.0.0, tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
@@ -5890,6 +5994,18 @@ tempfile@^1.1.1:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thenify-all@^1.0.0, thenify-all@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 throttleit@0.0.2:
   version "0.0.2"
@@ -6318,7 +6434,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.9:
+which@1, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -6405,6 +6521,12 @@ yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
+  dependencies:
+    camelcase "^3.0.0"
+
 yargs@^6.0.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -6422,6 +6544,24 @@ yargs@^6.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Use macOS built-in icons ([electron-named-image](https://github.com/ccnokes/electron-named-image)) instead of text for TouchBar:

![touchbar](https://user-images.githubusercontent.com/3001525/27730359-8565810a-5dbb-11e7-9052-9fd4feb72181.png)

- [x] Update screenshot in [the documentation](https://github.com/jhen0409/react-native-debugger/blob/master/docs/debugger-integration.md#developer-menu-integration).
- [x] Avoid install error on Linux / Windows
- [x] Fix lint errors

## Upstream issues

- [x] https://github.com/ccnokes/electron-named-image/issues/1