### PR TITLE
Migrate from babili to uglify-es for production build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - os: osx
       osx_image: xcode8.3
-    - os: osx
-      osx_image: xcode6.4
 addons:
   apt:
     sources:

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -45,10 +45,8 @@ bluebird@~2.9.24:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
 
 commander@^2.3.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.10.0.tgz#e1f5d3245de246d1a5ca04702fa1ad1bd7e405fe"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 conf@^1.0.0:
   version "1.1.2"
@@ -78,8 +76,8 @@ electron-named-image@^1.0.2:
     nan "^2.6.2"
 
 electron-store@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-1.1.0.tgz#3a06fbdc8c64ca14163dea054470f7561a7906aa"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-1.2.0.tgz#96f708f0188c7708907e9f9b7cba790bed6b989f"
   dependencies:
     conf "^1.0.0"
 
@@ -92,10 +90,6 @@ find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 is-obj@^1.0.0:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.6",
     "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1",
-    "babili-webpack-plugin": "^0.1.1",
     "cross-env": "^5.0.1",
     "devtron": "^1.4.0",
     "electron": "^1.7.3",
@@ -57,6 +56,7 @@
     "raw-loader": "^0.5.1",
     "spectron": "^3.6.4",
     "style-loader": "^0.18.2",
+    "uglifyjs-webpack-plugin": "^1.0.0-beta.1",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.5.0"
   },

--- a/webpack/main.prod.babel.js
+++ b/webpack/main.prod.babel.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
-import BabiliPlugin from 'babili-webpack-plugin';
+import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 import baseConfig from './base.babel';
 
 export default {
@@ -16,13 +16,10 @@ export default {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new BabiliPlugin(
-      {},
-      {
-        comments: false,
-      }
-    ),
     new webpack.optimize.ModuleConcatenationPlugin(),
+    new UglifyJSPlugin({
+      uglifyOptions: { output: { comments: false } },
+    }),
   ],
   target: 'electron-main',
   node: {

--- a/webpack/renderer.prod.babel.js
+++ b/webpack/renderer.prod.babel.js
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import BabiliPlugin from 'babili-webpack-plugin';
+import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 import baseConfig from './base.babel';
 
 const baseProdConfig = {
@@ -24,13 +24,10 @@ const baseProdConfig = {
       'process.env.NODE_ENV': JSON.stringify('production'),
       __REACT_DEVTOOLS_GLOBAL_HOOK__: 'false',
     }),
-    new BabiliPlugin(
-      {},
-      {
-        comments: false,
-      }
-    ),
     new webpack.optimize.ModuleConcatenationPlugin(),
+    new UglifyJSPlugin({
+      uglifyOptions: { output: { comments: false } },
+    }),
   ],
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,7 +1501,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.3.0, commander@^2.9.0:
+commander@2.9.0, commander@^2.3.0, commander@^2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -5807,7 +5807,7 @@ sumchecker@^2.0.1:
   dependencies:
     debug "^2.2.0"
 
-supports-color@3.1.2, supports-color@^3.1.1, supports-color@^3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5821,7 +5821,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@~3.2.3:
+supports-color@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -6017,6 +6017,13 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
+uglify-es@^3.0.21:
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.23.tgz#9682c6ae347269ad6b0628bd8b3d6a3b391707c0"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
+
 uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -6036,6 +6043,14 @@ uglifyjs-webpack-plugin@^0.4.4:
   dependencies:
     source-map "^0.5.6"
     uglify-js "^2.8.29"
+    webpack-sources "^1.0.1"
+
+uglifyjs-webpack-plugin@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.0-beta.1.tgz#595c14d8b85bedd708ab7a6e811894fbe0e69890"
+  dependencies:
+    source-map "^0.5.6"
+    uglify-es "^3.0.21"
     webpack-sources "^1.0.1"
 
 uid-number@^0.0.6:


### PR DESCRIPTION
Use `uglifyjs-webpack-plugin@^1.0.0-beta.1` instead of `babili-webpack-plugin`.

The latest version of `babili-webpack-plugin` has some bugs I haven't enough time to track it, and looks like `uglify-es` is stable and fast than `babili`.

### Build time (babili -> uglify-es)

* Renderer (bundle.js) - 84446ms -> 36193ms
* Renderer (RNDebuggerWorker.js) - 12004ms -> 11378ms
* Main - 5252ms -> 2820ms

### Bundle size (babili -> uglify-es)

* bundle.js - 1612138 -> 1602957
* RNDebuggerWorker.js - 56112 -> 55932
* main.js - 94726 -> 94393
