### PR TITLE
Remove unnecessary devtools tabs on devtools-opened

### DIFF
--- a/app/utils/devtools.js
+++ b/app/utils/devtools.js
@@ -4,10 +4,10 @@ let enabled = false;
 export const toggleOpenInEditor = (win, host, port) => {
   if (win.devToolsWebContents) {
     enabled = !enabled;
-    win.devToolsWebContents.executeJavaScript(`
+    win.devToolsWebContents.executeJavaScript(`(() => {
       ${getCatchConsoleLogScript(host, port)}
       window.__IS_OPEN_IN_EDITOR_ENABLED__ = ${enabled};
-    `);
+    })()`);
   }
 };
 

--- a/electron/devtools.js
+++ b/electron/devtools.js
@@ -33,3 +33,20 @@ export const catchConsoleLogLink = (win, host = 'localhost', port = 8081) => {
     win.devToolsWebContents.executeJavaScript(getCatchConsoleLogScript(host, port));
   }
 };
+
+export const removeUnecessaryTabs = win => {
+  if (!process.env.DEBUG_RNDEBUGGER && win.devToolsWebContents) {
+    return win.devToolsWebContents.executeJavaScript(`
+      const tabbedPane = UI.inspectorView._tabbedPane
+      if (tabbedPane) {
+        tabbedPane.closeTab('elements');
+        tabbedPane.closeTab('security');
+        tabbedPane.closeTab('timeline'); // Performance
+        tabbedPane.closeTab('audits');
+        tabbedPane.closeTab('resources'); // Application
+
+        tabbedPane._leftToolbar._contentElement.remove();
+      }
+    `);
+  }
+};

--- a/electron/devtools.js
+++ b/electron/devtools.js
@@ -30,13 +30,15 @@ export const getCatchConsoleLogScript = (host, port) => `
 
 export const catchConsoleLogLink = (win, host = 'localhost', port = 8081) => {
   if (win.devToolsWebContents) {
-    win.devToolsWebContents.executeJavaScript(getCatchConsoleLogScript(host, port));
+    win.devToolsWebContents.executeJavaScript(`(() => {
+      ${getCatchConsoleLogScript(host, port)}
+    })()`);
   }
 };
 
 export const removeUnecessaryTabs = win => {
   if (!process.env.DEBUG_RNDEBUGGER && win.devToolsWebContents) {
-    return win.devToolsWebContents.executeJavaScript(`
+    return win.devToolsWebContents.executeJavaScript(`(() => {
       const tabbedPane = UI.inspectorView._tabbedPane
       if (tabbedPane) {
         tabbedPane.closeTab('elements');
@@ -47,6 +49,6 @@ export const removeUnecessaryTabs = win => {
 
         tabbedPane._leftToolbar._contentElement.remove();
       }
-    `);
+    })()`);
   }
 };

--- a/electron/devtools.js
+++ b/electron/devtools.js
@@ -37,7 +37,11 @@ export const catchConsoleLogLink = (win, host = 'localhost', port = 8081) => {
 };
 
 export const removeUnecessaryTabs = win => {
-  if (!process.env.DEBUG_RNDEBUGGER && win.devToolsWebContents) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    !process.env.DEBUG_RNDEBUGGER &&
+    win.devToolsWebContents
+  ) {
     return win.devToolsWebContents.executeJavaScript(`(() => {
       const tabbedPane = UI.inspectorView._tabbedPane
       if (tabbedPane) {

--- a/electron/window.js
+++ b/electron/window.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { BrowserWindow, Menu } from 'electron';
 import Store from 'electron-store';
 import autoUpdate from './update';
-import { catchConsoleLogLink } from './devtools';
+import { catchConsoleLogLink, removeUnecessaryTabs } from './devtools';
 
 const store = new Store();
 
@@ -75,6 +75,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired }) => {
   win.webContents.on('devtools-opened', async () => {
     const { location } = await checkWindowInfo(win);
     catchConsoleLogLink(win, location.host, location.port);
+    removeUnecessaryTabs(win);
   });
   win.on('focus', () => onFocus(win));
   win.on('close', () => {


### PR DESCRIPTION
### Before

<img width="855" alt="2017-08-18 12 04 37" src="https://user-images.githubusercontent.com/3001525/29443843-8438043c-83a0-11e7-9cf2-e15de8ca4948.png">

### After

<img width="556" alt="2017-08-18 12 03 55" src="https://user-images.githubusercontent.com/3001525/29443842-84329f92-83a0-11e7-89f2-d974e2262ea1.png">

Keep the tabs that can inspect debugger worker, we have experienced the problem of some people confused about devtools tabs.