### PR TITLE
Clear network logs on RN app reload

### DIFF
--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -10,11 +10,14 @@
 // Take from https://github.com/facebook/react-native/blob/master/local-cli/server/util/debugger.html
 
 import WebSocket from 'ws';
+import { remote } from 'electron';
 import { bindActionCreators } from 'redux';
 import * as debuggerActions from '../actions/debugger';
 import { setDevMenuMethods } from '../utils/devMenu';
 import { tryADBReverse } from '../utils/adb';
+import { clearNetworkLogs } from '../utils/devtools';
 
+const currentWindow = remote.getCurrentWindow();
 const { SET_DEBUGGER_LOCATION } = debuggerActions;
 
 let worker;
@@ -83,10 +86,11 @@ const connectToDebuggerProxy = () => {
     // Special message that asks for a new JS runtime
     if (object.method === 'prepareJSRuntime') {
       shutdownJSRuntime();
+      createJSRuntime();
       if (process.env.NODE_ENV !== 'development') {
         console.clear();
+        clearNetworkLogs(currentWindow);
       }
-      createJSRuntime();
       ws.send(JSON.stringify({ replyID: object.id }));
     } else if (object.method === '$disconnected') {
       shutdownJSRuntime();

--- a/app/utils/devtools.js
+++ b/app/utils/devtools.js
@@ -12,3 +12,16 @@ export const toggleOpenInEditor = (win, host, port) => {
 };
 
 export const isOpenInEditorEnabled = () => enabled;
+
+// It's works only if Network tab have been opened,
+// otherwise it can't found `UI.panels.network`
+export const clearNetworkLogs = win => {
+  if (win.devToolsWebContents) {
+    return win.devToolsWebContents.executeJavaScript(`(() => {
+      const { network } = UI.panels;
+      if (network && network._clearButton && network._clearButton._clicked) {
+        network._clearButton._clicked({ consume: f => f });
+      }
+    })()`);
+  }
+};


### PR DESCRIPTION
It will be useful if [`Network Inspect`](https://github.com/jhen0409/react-native-debugger/blob/master/docs/debugger-integration.md#how-network-inspect-works) is enabled, but it's works only if Network tab have been opened.