### PR TITLE
Don't persist network inspect enable in local storage

### DIFF
--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -13,7 +13,7 @@ import WebSocket from 'ws';
 import { remote } from 'electron';
 import { bindActionCreators } from 'redux';
 import * as debuggerActions from '../actions/debugger';
-import { setDevMenuMethods } from '../utils/devMenu';
+import { setDevMenuMethods, networkInspect } from '../utils/devMenu';
 import { tryADBReverse } from '../utils/adb';
 import { clearNetworkLogs, selectRNDebuggerWorkerContext } from '../utils/devtools';
 
@@ -99,7 +99,7 @@ const connectToDebuggerProxy = () => {
       // Otherwise, pass through to the worker.
       if (!worker) return;
       if (object.method === 'executeApplicationScript') {
-        object.networkInspect = localStorage.networkInspect === 'enabled';
+        object.networkInspect = networkInspect.isEnabled();
         object.reactDevToolsPort = window.reactDevToolsPort;
         if (isScriptBuildForAndroid(object.url)) {
           // Reserve React Inspector port for debug via USB on Android real device

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -20,7 +20,10 @@ let storeLiftedState;
 /* slider, prev, next */
 let rightBar = {};
 
-const getBarItems = bar => Object.keys(bar).map(key => bar[key]).filter(barItem => !!barItem);
+const getBarItems = bar =>
+  Object.keys(bar)
+    .map(key => bar[key])
+    .filter(barItem => !!barItem);
 const setTouchBar = () =>
   currentWindow.setTouchBar([
     ...getBarItems(leftBar),
@@ -30,13 +33,14 @@ const setTouchBar = () =>
 const invokeDevMenuMethod = ({ name, args }) =>
   worker && worker.postMessage({ method: 'invokeDevMenuMethod', name, args });
 
-const networkInspect = {
-  isEnabled: () => localStorage.networkInspect === 'enabled',
-  getHighlightColor: () => (networkInspect.isEnabled() ? '#7A7A7A' : '#363636'),
+let networkInspectEnabled = false;
+export const networkInspect = {
+  isEnabled: () => !!networkInspectEnabled,
+  getHighlightColor: () => (networkInspectEnabled ? '#7A7A7A' : '#363636'),
   toggle() {
-    localStorage.networkInspect = networkInspect.isEnabled() ? 'disabled' : 'enabled';
+    networkInspectEnabled = !networkInspectEnabled;
   },
-  label: () => (networkInspect.isEnabled() ? 'Disable Network Inspect' : 'Enable Network Inspect'),
+  label: () => (networkInspectEnabled ? 'Disable Network Inspect' : 'Enable Network Inspect'),
 };
 
 const devMenuMethods = {
@@ -50,7 +54,7 @@ const devMenuMethods = {
     }
     invokeDevMenuMethod({
       name: 'networkInspect',
-      args: [networkInspect.isEnabled()],
+      args: [networkInspectEnabled],
     });
   },
   clearAsyncStorage: () => {


### PR DESCRIPTION
Related to https://github.com/jhen0409/react-native-debugger/issues/38#issuecomment-326305552, initially idea is it persisted even reload JS, so it can just be in memory instead of local storage.