### PR TITLE
Add warning if XHR have been replaced before enable Network Inspect

### DIFF
--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -1,4 +1,4 @@
-const isNativeMethod = fn => String(fn).indexOf('[native code]') > -1;
+const isWorkerMethod = fn => String(fn).indexOf('[native code]') > -1;
 
 let networkInspect;
 
@@ -10,7 +10,7 @@ export const toggleNetworkInspect = enabled => {
     return;
   }
   if (!enabled) return;
-  if (isNativeMethod(window.XMLHttpRequest) || isNativeMethod(window.FormData)) {
+  if (isWorkerMethod(window.XMLHttpRequest) || isWorkerMethod(window.FormData)) {
     console.warn(
       '[RNDebugger] ' +
         'I tried to enable Network Inspect but XHR ' +
@@ -76,7 +76,7 @@ const isForbiddenHeaderName = header =>
   header.startsWith('sec-');
 
 export const replaceForbiddenHeadersForWorkerXHR = () => {
-  if (!isNativeMethod(self.XMLHttpRequest)) return;
+  if (!isWorkerMethod(self.XMLHttpRequest)) return;
   const originalSetRequestHeader = self.XMLHttpRequest.prototype.setRequestHeader;
   self.XMLHttpRequest.prototype.setRequestHeader = function (header, value) {
     let replacedHeader = header;

--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -20,7 +20,7 @@ export const toggleNetworkInspect = enabled => {
   console.log(
     '[RNDebugger]',
     'Network Inspect is enabled,',
-    'you can open `Network` tab to inspect requests of `fetch` and `XMLHttpRequest`.'
+    'see the documentation (https://goo.gl/o3FvdC) for more information.'
   );
 };
 

--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -1,6 +1,6 @@
-let networkInspect;
-
 const isNativeMethod = fn => String(fn).indexOf('[native code]') > -1;
+
+let networkInspect;
 
 export const toggleNetworkInspect = enabled => {
   if (!enabled && networkInspect) {
@@ -15,7 +15,7 @@ export const toggleNetworkInspect = enabled => {
       '[RNDebugger] ' +
         'I tried to enable Network Inspect but XHR ' +
         "have been replaced by worker's XHR. " +
-        'You can disable the feature (documentation: https://goo.gl/f4bjnH)' +
+        'You can disable Network Inspect (documentation: https://goo.gl/f4bjnH) ' +
         'or tracking your app code if you have called ' +
         '`global.XMLHttpRequest = global.originalXMLHttpRequest`.'
     );


### PR DESCRIPTION
The would be helpful for case like https://github.com/jhen0409/react-native-debugger/issues/38#issuecomment-326313276 to debug.
