### PR TITLE
Use WebSocket from browser instead of `ws`

### DIFF
--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -138,7 +138,7 @@ const setDebuggerLoc = ({ host: packagerHost, port: packagerPort }) => {
     shutdownJSRuntime();
     socket.close();
   } else {
-    preconnect(connectToDebuggerProxy, true);
+    preconnect(connectToDebuggerProxy);
   }
 };
 

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -9,9 +9,9 @@
 
 // Take from https://github.com/facebook/react-native/blob/master/local-cli/server/util/debugger.html
 
-import WebSocket from 'ws';
 import { remote } from 'electron';
 import { bindActionCreators } from 'redux';
+import { checkPortStatus } from 'portscanner';
 import * as debuggerActions from '../actions/debugger';
 import { setDevMenuMethods, networkInspect } from '../utils/devMenu';
 import { tryADBReverse } from '../utils/adb';
@@ -63,7 +63,15 @@ const shutdownJSRuntime = () => {
 const isScriptBuildForAndroid = url =>
   url && (url.indexOf('.android.bundle') > -1 || url.indexOf('platform=android') > -1);
 
-const connectToDebuggerProxy = () => {
+const preconnect = async (fn, firstTimeout) => {
+  if (firstTimeout || await checkPortStatus(port, host) !== 'open') {
+    setTimeout(() => preconnect(fn), 500);
+    return;
+  }
+  socket = await fn();
+};
+
+const connectToDebuggerProxy = async () => {
   const ws = new WebSocket(`ws://${host}:${port}/debugger-proxy?role=debugger&name=Chrome`);
 
   const { setDebuggerStatus } = actions;
@@ -116,9 +124,7 @@ const connectToDebuggerProxy = () => {
     if (e.reason) {
       console.warn(e.reason);
     }
-    setTimeout(() => {
-      socket = connectToDebuggerProxy();
-    }, 500);
+    preconnect(connectToDebuggerProxy, true);
   };
   return ws;
 };
@@ -132,7 +138,7 @@ const setDebuggerLoc = ({ host: packagerHost, port: packagerPort }) => {
     shutdownJSRuntime();
     socket.close();
   } else {
-    socket = connectToDebuggerProxy();
+    preconnect(connectToDebuggerProxy, true);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jsan": "^3.1.9",
     "multiline-template": "^0.1.1",
     "node-watch": "^0.5.5",
+    "portscanner": "^2.1.1",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dev-utils": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1",
-    "whatwg-fetch": "^2.0.3"
+    "whatwg-fetch": "^2.0.3",
+    "ws": "^3.1.0"
   },
   "dependencies": {
     "adbkit": "^2.11.0",
@@ -85,8 +86,7 @@
     "remotedev-app": "^0.10.8",
     "remotedev-monitor-components": "^0.0.5",
     "remotedev-slider": "^1.1.3",
-    "remotedev-utils": "^0.1.4",
-    "ws": "^3.1.0"
+    "remotedev-utils": "^0.1.4"
   },
   "optionalDependencies": {
     "electron-named-image": "^1.0.2"

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -32,10 +32,6 @@ export default {
   },
   externals: [
     'react-devtools-core/standalone',
-    // just avoid warning.
-    // this is not really used from ws. (it used fallback)
-    'utf-8-validate',
-    'bufferutil',
     // https://github.com/sindresorhus/conf/blob/master/index.js#L13
     'electron-store',
     'adbkit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,7 +312,7 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.5.2:
+async@1.5.2, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -3581,6 +3581,12 @@ is-my-json-valid@^2.10.0:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
+is-number-like@^1.0.3:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/is-number-like/-/is-number-like-1.0.8.tgz#2e129620b50891042e44e9bbbb30593e75cfbbe3"
+  dependencies:
+    lodash.isfinite "^3.3.2"
+
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
@@ -4038,6 +4044,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isfinite@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -4907,6 +4917,13 @@ portfinder@^1.0.9:
     async "^1.5.2"
     debug "^2.2.0"
     mkdirp "0.5.x"
+
+portscanner@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/portscanner/-/portscanner-2.1.1.tgz#eabb409e4de24950f5a2a516d35ae769343fbb96"
+  dependencies:
+    async "1.5.2"
+    is-number-like "^1.0.3"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Make connection same with [official debugger](https://github.com/facebook/react-native/blob/master/local-cli/server/util/debugger.html), just ensure it won't make other problems, may even fix #32.

To avoid browser `WebSocket` connection errors in console, I just made it connect only if the `port` is listening.