### PR TITLE
Add method to show AsyncStorage contents by console.table

### DIFF
--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -57,6 +57,9 @@ const devMenuMethods = {
       args: [networkInspectEnabled],
     });
   },
+  showAsyncStorage: () => {
+    invokeDevMenuMethod({ name: 'showAsyncStorage' });
+  },
   clearAsyncStorage: () => {
     if (confirm('Call `AsyncStorage.clear()` in current React Native debug session?')) {
       invokeDevMenuMethod({ name: 'clearAsyncStorage' });
@@ -80,6 +83,8 @@ contextMenu({
         item('Toggle Element Inspector', n, devMenuMethods.toggleElementInspector),
       availableMethods.includes('show') && item('Show Developer Menu', n, devMenuMethods.show),
       item(networkInspect.label(), n, devMenuMethods.networkInspect),
+      availableMethods.includes('showAsyncStorage') &&
+        item('Log AsyncStorage content', n, devMenuMethods.showAsyncStorage),
       availableMethods.includes('clearAsyncStorage') &&
         item('Clear AsyncStorage', n, devMenuMethods.clearAsyncStorage),
       separator,

--- a/app/worker/asyncStorage.js
+++ b/app/worker/asyncStorage.js
@@ -1,0 +1,15 @@
+export const getClearAsyncStorageFn = AsyncStorage => {
+  if (!AsyncStorage.clear) return;
+  return () => AsyncStorage.clear().catch(f => f);
+};
+
+export const getShowAsyncStorageFn = AsyncStorage => {
+  if (!AsyncStorage.getAllKeys || !AsyncStorage.getItem) return;
+  return async () => {
+    const keys = await AsyncStorage.getAllKeys();
+    const items = await Promise.all(keys.map(key => AsyncStorage.getItem(key)));
+    const table = {};
+    keys.forEach((key, index) => (table[key] = { content: items[index] }));
+    console.table(table);
+  };
+};

--- a/app/worker/asyncStorage.js
+++ b/app/worker/asyncStorage.js
@@ -9,7 +9,11 @@ export const getShowAsyncStorageFn = AsyncStorage => {
     const keys = await AsyncStorage.getAllKeys();
     const items = await Promise.all(keys.map(key => AsyncStorage.getItem(key)));
     const table = {};
-    keys.forEach((key, index) => (table[key] = { content: items[index] }));
-    console.table(table);
+    if (keys.length) {
+      keys.forEach((key, index) => (table[key] = { content: items[index] }));
+      console.table(table);
+    } else {
+      console.log('[RNDebugger] No AsyncStorage content.');
+    }
   };
 };

--- a/app/worker/devMenu.js
+++ b/app/worker/devMenu.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import { toggleNetworkInspect } from './networkInspect';
+import { getClearAsyncStorageFn, getShowAsyncStorageFn } from './asyncStorage';
 
 let availableDevMenuMethods = {};
 
@@ -20,8 +21,12 @@ export const checkAvailableDevMenuMethods = async (
     ...DevSettings,
     show: showDevMenu,
     networkInspect: toggleNetworkInspect,
-    clearAsyncStorage: AsyncStorage.clear ? () => AsyncStorage.clear().catch(f => f) : undefined,
+    showAsyncStorage: getShowAsyncStorageFn(AsyncStorage),
+    clearAsyncStorage: getClearAsyncStorageFn(AsyncStorage),
   };
+  if (methods.showAsyncStorage) {
+    window.showAsyncStorageContentInDev = methods.showAsyncStorage;
+  }
   const result = Object.keys(methods).filter(key => !!methods[key]);
   availableDevMenuMethods = methods;
 

--- a/docs/debugger-integration.md
+++ b/docs/debugger-integration.md
@@ -31,8 +31,9 @@ $ react-native link react-native-devsettings-android
 
 Other features (cross-platform):
 
-* Clear AsyncStorage
 * Enable / Disable [Network Inspect](#how-network-inspect-works)
+* Log AsyncStorage content (`showAsyncStorageContentInDev()` in console)
+* Clear AsyncStorage
 
 #### macOS Touch Bar support
 


### PR DESCRIPTION
It would be a good start for #108.

Added the context menu item `Log AsyncStorage content`. Also assign the method to global, so we can just type `showAsyncStorageContentInDev()` in console.