### PR TITLE
Fix `show` event of registered keyboard shortcuts

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -11,7 +11,6 @@ import FormInput from '../components/FormInput';
 import Draggable from '../components/Draggable';
 import { catchConsoleLogLink } from '../../electron/devtools';
 
-const localShortcut = remote.getGlobal('localShortcut');
 const currentWindow = remote.getCurrentWindow();
 
 const styles = {
@@ -126,7 +125,6 @@ export default class App extends Component {
   removeAllListeners() {
     ipcRenderer.removeAllListeners('toggle-devtools');
     ipcRenderer.removeAllListeners('set-debugger-loc');
-    localShortcut.unregisterAll(currentWindow);
   }
 
   background = (

--- a/app/index.js
+++ b/app/index.js
@@ -7,6 +7,7 @@ import launchEditor from 'react-dev-utils/launchEditor';
 import App from './containers/App';
 import configureStore from './store/configureStore';
 import { beforeWindowClose } from './actions/debugger';
+import { invokeDevMethod } from './utils/devMenu';
 import { client, tryADBReverse } from './utils/adb';
 import { toggleOpenInEditor, isOpenInEditorEnabled } from './utils/devtools';
 
@@ -50,6 +51,8 @@ window.toggleOpenInEditor = () => {
   return toggleOpenInEditor(currentWindow, host, port);
 };
 window.isOpenInEditorEnabled = () => isOpenInEditorEnabled(currentWindow);
+
+window.invokeDevMethod = name => invokeDevMethod(name)();
 
 // Package will missing /usr/local/bin,
 // we need fix it for ensure child process work

--- a/app/utils/devMenu.js
+++ b/app/utils/devMenu.js
@@ -2,8 +2,6 @@ import { remote } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { item, n, toggleDevTools, separator } from '../../electron/menu/util';
 
-const localShortcut = remote.getGlobal('localShortcut');
-
 const { nativeImage } = remote;
 const { TouchBarButton, TouchBarSlider } = remote.TouchBar || {};
 const currentWindow = remote.getCurrentWindow();
@@ -95,14 +93,11 @@ contextMenu({
       .concat(defaultContextMenuItems),
 });
 
-const invokeDevMethod = name => () => {
+export const invokeDevMethod = name => () => {
   if (availableMethods.includes(name)) {
     return devMenuMethods[name]();
   }
 };
-const keyPrefix = process.platform === 'darwin' ? 'Command' : 'Ctrl';
-localShortcut.register(currentWindow, `${keyPrefix}+R`, invokeDevMethod('reload'));
-localShortcut.register(currentWindow, `${keyPrefix}+I`, invokeDevMethod('toggleElementInspector'));
 
 const icon = name => nativeImage.createFromBuffer(namedImage.getImageNamed(name));
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import { app, ipcMain, session, BrowserWindow, Menu } from 'electron';
-import localShortcut from 'electron-localshortcut';
 import installExtensions from './extensions';
 import { checkWindowInfo, createWindow } from './window';
 import { startListeningHandleURL } from './url-handle';
@@ -15,8 +14,6 @@ const isSecondInstance = app.makeSingleInstance(() => {
 if (isSecondInstance) {
   app.quit();
 }
-
-global.localShortcut = localShortcut;
 
 const iconPath = path.resolve(__dirname, 'logo.png');
 const defaultOptions = { iconPath };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "adbkit": "^2.11.0",
     "electron-context-menu": "^0.9.1",
     "electron-gh-releases": "^2.0.4",
-    "electron-localshortcut": "^2.0.2",
     "electron-store": "^1.2.0",
     "jsan": "^3.1.9",
     "multiline-template": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,13 +2169,6 @@ electron-is-dev@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
 
-electron-localshortcut@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-2.0.2.tgz#6a1adcd6514c957328ec7912f5ccb5e1c10706db"
-  dependencies:
-    debug "^2.6.8"
-    electron-is-accelerator "^0.1.0"
-
 electron-localshortcut@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-3.0.2.tgz#df9cebe64140f4e58b680aacb2bd6278ae38ee61"


### PR DESCRIPTION
Fix #153.

Just use electron API instead of the module, because it almost no difference in our use case, in addition to register the event handlers.