### PR TITLE
Refactor `Toggle Device Sync` feature

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -62,20 +62,10 @@ export default class App extends Component {
     actions: PropTypes.object.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      syncDevices: true,
-    };
-  }
-
   componentDidMount() {
     const { toggleDevTools } = this.props.actions.setting;
     ipcRenderer.on('toggle-devtools', (e, name) => toggleDevTools(name));
-    ipcRenderer.on('sync-state',
-      (event, arg) => this.state.syncDevices && this.props.debugger.syncState(arg));
-    ipcRenderer.on('toggle-sync', () => this.toggleSync());
-
+    ipcRenderer.on('sync-state', (event, arg) => this.props.actions.debugger.syncState(arg));
     ipcRenderer.on('set-debugger-loc', (e, payload) => {
       const location = JSON.parse(payload);
       this.setDebuggerLocation(location);
@@ -130,13 +120,6 @@ export default class App extends Component {
       };
     }
     return { redux: size, react: 1 - size };
-  }
-
-  toggleSync() {
-    console.warn(`Syncing devices: ${!this.state.syncDevices}`);
-    this.setState({
-      syncDevices: !this.state.syncDevices,
-    });
   }
 
   removeAllListeners() {

--- a/app/middlewares/reduxAPI.js
+++ b/app/middlewares/reduxAPI.js
@@ -1,5 +1,5 @@
 import { bindActionCreators } from 'redux';
-import { ipcRenderer } from 'electron';
+import { remote, ipcRenderer } from 'electron';
 import { UPDATE_STATE, LIFTED_ACTION } from 'remotedev-app/lib/constants/actionTypes';
 import { DISCONNECTED } from 'remotedev-app/lib/constants/socketActionTypes';
 import { nonReduxDispatch } from 'remotedev-app/lib/utils/monitorActions';
@@ -39,7 +39,7 @@ const toWorker = ({ message, action, state, toAll }) => {
   });
 };
 
-const postImportMessage = (state) => {
+const postImportMessage = state => {
   if (!worker) return;
 
   const instances = store.getState().instances;
@@ -78,7 +78,9 @@ const removeWorker = () => {
   worker = null;
 };
 
-const syncLiftedState = (liftedState) => {
+const syncLiftedState = liftedState => {
+  if (!remote.getGlobal('isSyncState')()) return;
+
   const actionsById = liftedState.actionsById;
   const payload = [];
   liftedState.stagedActionIds.slice(1).forEach(id => {
@@ -105,7 +107,9 @@ export default inStore => {
       toWorker(action);
     }
     if (
-      action.type === UPDATE_STATE || action.type === LIFTED_ACTION || action.type === SYNC_STATE
+      action.type === UPDATE_STATE ||
+      action.type === LIFTED_ACTION ||
+      action.type === SYNC_STATE
     ) {
       next(action);
       const state = store.getState();

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ import installExtensions from './extensions';
 import { checkWindowInfo, createWindow } from './window';
 import { startListeningHandleURL } from './url-handle';
 import { createMenuTemplate } from './menu';
+import { sendSyncState } from './sync-state';
 
 const iconPath = path.resolve(__dirname, 'logo.png');
 const defaultOptions = { iconPath };
@@ -34,13 +35,7 @@ ipcMain.on('check-port-available', async (event, arg) => {
   event.sender.send('check-port-available-reply', true);
 });
 
-ipcMain.on('sync-state', async (event, arg) => {
-  BrowserWindow.getAllWindows()
-    .filter(win => Number(win.webContents.id) !== event.sender.id)
-    .forEach(win => {
-      win.webContents.send('sync-state', arg);
-    });
-});
+ipcMain.on('sync-state', sendSyncState);
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length !== 0) return;

--- a/electron/menu/darwin.js
+++ b/electron/menu/darwin.js
@@ -15,8 +15,8 @@ import {
   resetZoom,
   haveOpenedWindow,
   toggleOpenInEditor,
-  toggleDeviceSync,
 } from './util';
+import { isSyncState, toggleSyncState } from '../sync-state';
 
 const getWin = () => BrowserWindow.getFocusedWindow();
 
@@ -46,7 +46,10 @@ export default ({ iconPath }) => [
         type: 'checkbox',
         checked: false,
       }),
-      item('Toggle Device Sync', n, () => toggleDeviceSync()),
+      item('Toggle Device Sync', n, toggleSyncState, {
+        type: 'checkbox',
+        checked: isSyncState(),
+      }),
       separator,
       item('Minimize', 'Command+M', n, { selector: 'performMiniaturize:' }),
       item('Close', 'Command+W', n, { selector: 'performClose:' }),

--- a/electron/menu/linux+win.js
+++ b/electron/menu/linux+win.js
@@ -16,8 +16,8 @@ import {
   resetZoom,
   haveOpenedWindow,
   toggleOpenInEditor,
-  toggleDeviceSync,
 } from './util';
+import { toggleSyncState, isSyncState } from '../sync-state';
 
 const getWin = () => BrowserWindow.getFocusedWindow();
 const viewItems =
@@ -45,7 +45,10 @@ export default ({ iconPath }) => [
         type: 'checkbox',
         checked: false,
       }),
-      item('Toggle Device Sync', n, () => toggleDeviceSync()),
+      item('Toggle Device Sync', n, toggleSyncState, {
+        type: 'checkbox',
+        checked: isSyncState(),
+      }),
       separator,
       item('Close', 'Ctrl+W', () => close(getWin())),
     ],

--- a/electron/menu/util.js
+++ b/electron/menu/util.js
@@ -12,12 +12,6 @@ const detail = multiline`
   | https://github.com/zalmoxisus/remotedev-app
 `;
 
-export const toggleDeviceSync = () => {
-  BrowserWindow.getAllWindows().forEach(window => {
-    window.webContents.send('toggle-sync');
-  });
-};
-
 export const showAboutDialog = iconPath =>
   (remote ? remote.dialog : dialog).showMessageBox({
     title: 'About',

--- a/electron/sync-state.js
+++ b/electron/sync-state.js
@@ -1,18 +1,18 @@
 import { BrowserWindow } from 'electron';
 
-let syncDevices = false;
+let syncState = false;
+
+export const isSyncState = () => syncState;
 
 // Take by renderer
-const isSyncDevices = () => syncDevices;
-
-global.isSyncDevices = isSyncDevices;
+global.isSyncState = isSyncState;
 
 export const toggleSyncState = () => {
-  syncDevices = !syncDevices;
+  syncState = !syncState;
 };
 
 export const sendSyncState = (event, payload) => {
-  if (!isSyncDevices) return;
+  if (!isSyncState) return;
 
   BrowserWindow.getAllWindows()
     .filter(win => Number(win.webContents.id) !== event.sender.id)

--- a/electron/sync-state.js
+++ b/electron/sync-state.js
@@ -1,0 +1,22 @@
+import { BrowserWindow } from 'electron';
+
+let syncDevices = false;
+
+// Take by renderer
+const isSyncDevices = () => syncDevices;
+
+global.isSyncDevices = isSyncDevices;
+
+export const toggleSyncState = () => {
+  syncDevices = !syncDevices;
+};
+
+export const sendSyncState = (event, payload) => {
+  if (!isSyncDevices) return;
+
+  BrowserWindow.getAllWindows()
+    .filter(win => Number(win.webContents.id) !== event.sender.id)
+    .forEach(win => {
+      win.webContents.send('sync-state', payload);
+    });
+};

--- a/examples/counter-with-redux/yarn.lock
+++ b/examples/counter-with-redux/yarn.lock
@@ -5624,7 +5624,7 @@ webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-"websql@github:expo/node-websql#18.0.0":
+websql@expo/node-websql#18.0.0:
   version "0.4.4"
   resolved "https://codeload.github.com/expo/node-websql/tar.gz/e364fa65146a9e2157a19e5c719e7702c2b6b87a"
   dependencies:


### PR DESCRIPTION
Other changes:

- Fix: `this.props.debugger.syncState` -> `this.props.actions.debugger.syncState`
- default value of sync state: `true` -> `false`
- Menu item `Toggle Device Sync` is now as checkbox