### PR TITLE
Fix Blob error for use `fetch` if Network Inspect enabled

### DIFF
--- a/__e2e__/app.spec.js
+++ b/__e2e__/app.spec.js
@@ -34,8 +34,7 @@ describe('Application launch', () => {
       path: electronPath,
       args: ['--user-dir=__e2e__/tmp', 'dist'],
       env: {
-        REACT_ONLY_FOR_LOCAL: 1,
-        OPEN_DEVTOOLS: 0,
+        E2E_TEST: 1,
       },
     });
     return app.start();
@@ -229,7 +228,7 @@ describe('Application launch', () => {
 
     let currentInstance = 'Autoselect instances'; // Default instance
     const wait = () => delay(750);
-    const selectInstance = async (instance) => {
+    const selectInstance = async instance => {
       const { client } = app;
       await client
         .element(`//div[text()="${currentInstance}"]`)

--- a/app/index.js
+++ b/app/index.js
@@ -15,6 +15,9 @@ const currentWindow = remote.getCurrentWindow();
 
 webFrame.setZoomFactor(1);
 webFrame.setZoomLevelLimits(1, 1);
+if (process.env.E2E_TEST) {
+  webFrame.registerURLSchemeAsPrivileged('file');
+}
 
 // Prevent dropped file
 document.addEventListener('drop', e => {

--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -2,11 +2,17 @@ const isWorkerMethod = fn => String(fn).indexOf('[native code]') > -1;
 
 let networkInspect;
 
+/* eslint-disable no-underscore-dangle */
 export const toggleNetworkInspect = enabled => {
   if (!enabled && networkInspect) {
+    window.fetch = networkInspect.fetch;
     window.XMLHttpRequest = networkInspect.XMLHttpRequest;
     window.FormData = networkInspect.FormData;
+    window.Blob = networkInspect.Blob;
     networkInspect = null;
+    if (window._fetchSupport) {
+      window._fetchSupport.blob = !!window._fetchSupport._blob;
+    }
     return;
   }
   if (!enabled) return;
@@ -24,11 +30,20 @@ export const toggleNetworkInspect = enabled => {
   networkInspect = {
     XMLHttpRequest: window.XMLHttpRequest,
     FormData: window.FormData,
+    Blob: window.Blob,
   };
   window.XMLHttpRequest = window.originalXMLHttpRequest
     ? window.originalXMLHttpRequest
     : window.XMLHttpRequest;
   window.FormData = window.originalFormData ? window.originalFormData : window.FormData;
+  window.Blob = window.originalBlob ? window.originalBlob : window.Blob;
+
+  // Don't enable blob for use native XMLHttpRequest
+  // See https://github.com/jhen0409/react-native-debugger/issues/56
+  if (window._fetchSupport) {
+    window._fetchSupport._blob = window._fetchSupport.blob;
+    window._fetchSupport.blob = false;
+  }
 
   console.log(
     '[RNDebugger]',
@@ -36,6 +51,13 @@ export const toggleNetworkInspect = enabled => {
     'see the documentation (https://goo.gl/yEcRrU) for more information.'
   );
 };
+
+// Get the `support` variable in favor of toggleNetworkInspect
+export const replaceFetchCode = source =>
+  source.replace(
+    /if \(self.fetch\) {\n\s+return;\n\s+}\n\s+var support = {/g,
+    'if (self.fetch) {\n      return;\n    }\n    var support = self._fetchSupport = {'
+  );
 
 /*
  * `originalXMLHttpRequest` haven't permission to set forbidden header name

--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -9,6 +9,7 @@ export const toggleNetworkInspect = enabled => {
     window.XMLHttpRequest = networkInspect.XMLHttpRequest;
     window.FormData = networkInspect.FormData;
     window.Blob = networkInspect.Blob;
+    window.FileReader = networkInspect.FileReader;
     networkInspect = null;
     if (window._fetchSupport) {
       window._fetchSupport.blob = !!window._fetchSupport._blob;
@@ -31,12 +32,14 @@ export const toggleNetworkInspect = enabled => {
     XMLHttpRequest: window.XMLHttpRequest,
     FormData: window.FormData,
     Blob: window.Blob,
+    FileReader: window.FileReader,
   };
   window.XMLHttpRequest = window.originalXMLHttpRequest
     ? window.originalXMLHttpRequest
     : window.XMLHttpRequest;
   window.FormData = window.originalFormData ? window.originalFormData : window.FormData;
   window.Blob = window.originalBlob ? window.originalBlob : window.Blob;
+  window.FileReader = window.originalFileReader ? window.originalFileReader : window.FileReader;
 
   // Don't enable blob for use native XMLHttpRequest
   // See https://github.com/jhen0409/react-native-debugger/issues/56

--- a/app/worker/setup.js
+++ b/app/worker/setup.js
@@ -6,13 +6,5 @@ import {
 // Add the missing `global` for WebWorker
 self.global = self;
 
-/*
- * Currently Blob is not supported for RN,
- * we should remove it in WebWorker because it will used for `whatwg-fetch`
- */
-if (self.Blob && self.Blob.toString() === 'function Blob() { [native code] }') {
-  delete self.Blob;
-}
-
 replaceForbiddenHeadersForWorkerXHR();
 addURIWarningForWorkerFormData();

--- a/electron/window.js
+++ b/electron/window.js
@@ -87,7 +87,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired }) => {
     win.webContents.setZoomLevel(store.get('zoomLevel', 0));
     win.focus();
     registerShortcuts(win);
-    if (process.env.OPEN_DEVTOOLS !== '0' && !isPortSettingRequired) {
+    if (process.env.E2E_TEST !== '1' && !isPortSettingRequired) {
       win.openDevTools();
     }
     if (BrowserWindow.getAllWindows().length === 1) {


### PR DESCRIPTION
Try to fix #209 with replace `whatwg-fetch` code in app bundle, so we can change [`support.blob`](https://github.com/github/fetch/blob/master/fetch.js#L11) to false if Network Inspect is on.

This may need more testing.