### PR TITLE
Delta bundler support

### DIFF
--- a/__e2e__/app.spec.js
+++ b/__e2e__/app.spec.js
@@ -69,9 +69,6 @@ describe('Application launch', () => {
     await delay(2000);
     const title = await browserWindow.getTitle();
     expect(title).toBe('React Native Debugger - Attempting reconnection (port 8081)');
-
-    // Avoid RND clear logs
-    await app.webContents.executeJavaScript('console.clear = noop => noop');
   });
 
   it('should portfile (for debugger-open usage) always exists in home dir', async () => {
@@ -316,9 +313,16 @@ describe('Application launch', () => {
       logs.forEach(log =>
         console.log(`Message: ${log.message}\nSource: ${log.source}\nLevel: ${log.level}`)
       );
-      expect(logs.length).toEqual(1);
-      const [formDataWarning] = logs;
+      expect(logs.length).toEqual(2);
+      const [notFoundDeltaBundleError, formDataWarning] = logs;
 
+      expect(notFoundDeltaBundleError.source).toBe('network');
+      expect(notFoundDeltaBundleError.level).toBe('SEVERE');
+      expect(
+        notFoundDeltaBundleError.message.indexOf(
+          'app.delta.js - Failed to load resource: net::ERR_FILE_NOT_FOUND'
+        ) > 0
+      ).toBeTruthy();
       expect(formDataWarning.source).toBe('worker');
       expect(formDataWarning.level).toBe('WARNING');
       expect(

--- a/__e2e__/app.spec.js
+++ b/__e2e__/app.spec.js
@@ -34,8 +34,7 @@ describe('Application launch', () => {
       path: electronPath,
       args: ['--user-dir=__e2e__/tmp', 'dist'],
       env: {
-        REACT_ONLY_FOR_LOCAL: 1,
-        OPEN_DEVTOOLS: 0,
+        E2E_TEST: 1,
       },
     });
     return app.start();
@@ -229,7 +228,7 @@ describe('Application launch', () => {
 
     let currentInstance = 'Autoselect instances'; // Default instance
     const wait = () => delay(750);
-    const selectInstance = async (instance) => {
+    const selectInstance = async instance => {
       const { client } = app;
       await client
         .element(`//div[text()="${currentInstance}"]`)

--- a/app/index.js
+++ b/app/index.js
@@ -15,6 +15,9 @@ const currentWindow = remote.getCurrentWindow();
 
 webFrame.setZoomFactor(1);
 webFrame.setZoomLevelLimits(1, 1);
+if (process.env.E2E_TEST) {
+  webFrame.registerURLSchemeAsPrivileged('file');
+}
 
 // Prevent dropped file
 document.addEventListener('drop', e => {

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -121,10 +121,9 @@ const connectToDebuggerProxy = async () => {
         }
         // Check Delta support
         try {
-          const deltaUrl = object.url.replace('index.bundle', 'index.delta');
-          await fetch(deltaUrl);
+          const url = await deltaUrlToBlobUrl(object.url.replace('.bundle', '.delta'));
           clearLogs();
-          worker.postMessage({ ...object, url: await deltaUrlToBlobUrl(deltaUrl) });
+          worker.postMessage({ ...object, url });
           return;
         } catch (e) {
           clearLogs();

--- a/app/middlewares/delta/DeltaPatcher.js
+++ b/app/middlewares/delta/DeltaPatcher.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+/**
+ * This file is a copy of the reference `DeltaPatcher`, located in
+ * metro. The reason to not reuse that file is that in this context
+ * we cannot have flow annotations or CJS syntax (since this file is directly)
+ * injected into a static HTML page.
+ *
+ * TODO: Find a simple and lightweight way to compile `DeltaPatcher` to avoid
+ * having this duplicated file.
+ */
+
+/**
+ * This is a reference client for the Delta Bundler: it maintains cached the
+ * last patched bundle delta and it's capable of applying new Deltas received
+ * from the Bundler.
+ */
+export default class DeltaPatcher {
+  constructor() {
+    this._lastBundle = {
+      pre: new Map(),
+      post: new Map(),
+      modules: new Map(),
+      id: undefined,
+    };
+    this._initialized = false;
+    this._lastNumModifiedFiles = 0;
+    this._lastModifiedDate = new Date();
+  }
+
+  static get(id) {
+    let deltaPatcher = this._deltaPatchers.get(id);
+
+    if (!deltaPatcher) {
+      deltaPatcher = new DeltaPatcher();
+      this._deltaPatchers.set(id, deltaPatcher);
+    }
+
+    return deltaPatcher;
+  }
+
+  /**
+   * Applies a Delta Bundle to the current bundle.
+   */
+  applyDelta(deltaBundle) {
+    // Make sure that the first received delta is a fresh one.
+    if (!this._initialized && !deltaBundle.reset) {
+      throw new Error('DeltaPatcher should receive a fresh Delta when being initialized');
+    }
+
+    this._initialized = true;
+
+    // Reset the current delta when we receive a fresh delta.
+    if (deltaBundle.reset) {
+      this._lastBundle = {
+        pre: new Map(),
+        post: new Map(),
+        modules: new Map(),
+        id: undefined,
+      };
+    }
+
+    this._lastNumModifiedFiles =
+      deltaBundle.pre.size + deltaBundle.post.size + deltaBundle.delta.size;
+
+    if (this._lastNumModifiedFiles > 0) {
+      this._lastModifiedDate = new Date();
+    }
+
+    this._patchMap(this._lastBundle.pre, deltaBundle.pre);
+    this._patchMap(this._lastBundle.post, deltaBundle.post);
+    this._patchMap(this._lastBundle.modules, deltaBundle.delta);
+
+    this._lastBundle.id = deltaBundle.id;
+
+    return this;
+  }
+
+  getLastBundleId() {
+    return this._lastBundle.id;
+  }
+
+  /**
+   * Returns the number of modified files in the last received Delta. This is
+   * currently used to populate the `X-Metro-Files-Changed-Count` HTTP header
+   * when metro serves the whole JS bundle, and can potentially be removed once
+   * we only send the actual deltas to clients.
+   */
+  getLastNumModifiedFiles() {
+    return this._lastNumModifiedFiles;
+  }
+
+  getLastModifiedDate() {
+    return this._lastModifiedDate;
+  }
+
+  getAllModules() {
+    return [].concat(
+      Array.from(this._lastBundle.pre.values()),
+      Array.from(this._lastBundle.modules.values()),
+      Array.from(this._lastBundle.post.values())
+    );
+  }
+
+  _patchMap(original, patch) {
+    for (const [key, value] of patch.entries()) {
+      if (value == null) {
+        original.delete(key);
+      } else {
+        original.set(key, value);
+      }
+    }
+  }
+}
+
+DeltaPatcher._deltaPatchers = new Map();

--- a/app/middlewares/delta/DeltaPatcher.js
+++ b/app/middlewares/delta/DeltaPatcher.js
@@ -7,6 +7,8 @@
  * @format
  */
 
+/* eslint-disable no-underscore-dangle */
+
 /**
  * This file is a copy of the reference `DeltaPatcher`, located in
  * metro. The reason to not reuse that file is that in this context

--- a/app/middlewares/delta/deltaUrlToBlobUrl.js
+++ b/app/middlewares/delta/deltaUrlToBlobUrl.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DeltaPatcher from './DeltaPatcher';
+
+const cachedBundleUrls = new Map();
+
+/**
+ * Converts the passed delta URL into an URL object containing already the
+ * whole JS bundle Blob.
+ */
+export default async function deltaUrlToBlobUrl(deltaUrl) {
+  const cachedBundle = cachedBundleUrls.get(deltaUrl);
+
+  const deltaBundleId = cachedBundle ? `&deltaBundleId=${cachedBundle.id}` : '';
+
+  const data = await fetch(deltaUrl + deltaBundleId);
+  const bundle = await data.json();
+
+  const deltaPatcher = DeltaPatcher.get(bundle.id).applyDelta({
+    pre: new Map(bundle.pre),
+    post: new Map(bundle.post),
+    delta: new Map(bundle.delta),
+    reset: bundle.reset,
+  });
+
+  // If nothing changed, avoid recreating a bundle blob by reusing the
+  // previous one.
+  if (deltaPatcher.getLastNumModifiedFiles() === 0 && cachedBundle) {
+    return cachedBundle.url;
+  }
+
+  // Clean up the previous bundle URL to not leak memory.
+  if (cachedBundle) {
+    URL.revokeObjectURL(cachedBundle.url);
+  }
+
+  // To make Source Maps work correctly, we need to add a newline between
+  // modules.
+  const blobContent = deltaPatcher.getAllModules().map(module => `${module}\n`);
+
+  // Build the blob with the whole JS bundle.
+  const blob = new Blob(blobContent, {
+    type: 'application/javascript',
+  });
+
+  const bundleUrl = URL.createObjectURL(blob);
+  cachedBundleUrls.set(deltaUrl, {
+    id: bundle.id,
+    url: bundleUrl,
+  });
+
+  return bundleUrl;
+}

--- a/electron/window.js
+++ b/electron/window.js
@@ -87,7 +87,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired }) => {
     win.webContents.setZoomLevel(store.get('zoomLevel', 0));
     win.focus();
     registerShortcuts(win);
-    if (process.env.OPEN_DEVTOOLS !== '0' && !isPortSettingRequired) {
+    if (process.env.E2E_TEST !== '1' && !isPortSettingRequired) {
       win.openDevTools();
     }
     if (BrowserWindow.getAllWindows().length === 1) {


### PR DESCRIPTION
Related to #158, it will fetch bundle with `index.delta` instead of `index.bundle`. (RN >= 0.52)

Also fallback to `index.bundle` if the packager doesn't support Delta. (RN < 0.52 or another bundler)