### PR TITLE
Fix Blob error for use `fetch` if Network Inspect enabled

### DIFF
--- a/app/middlewares/delta/DeltaPatcher.js
+++ b/app/middlewares/delta/DeltaPatcher.js
@@ -80,9 +80,9 @@ export default class DeltaPatcher {
       this._lastModifiedDate = new Date();
     }
 
-    this._patchMap(this._lastBundle.pre, deltaBundle.pre);
-    this._patchMap(this._lastBundle.post, deltaBundle.post);
-    this._patchMap(this._lastBundle.modules, deltaBundle.delta);
+    this._patchMap(this._lastBundle.pre, deltaBundle.pre, 'pre');
+    this._patchMap(this._lastBundle.post, deltaBundle.post, 'post');
+    this._patchMap(this._lastBundle.modules, deltaBundle.delta, 'delta');
 
     this._lastBundle.id = deltaBundle.id;
 
@@ -115,11 +115,11 @@ export default class DeltaPatcher {
     );
   }
 
-  _patchMap(original, patch) {
+  _patchMap(original, patch, type) {
     for (const [key, value] of patch.entries()) {
       if (value == null) {
         original.delete(key);
-      } else if (!this._fetchPolyfillPatched && checkFetchExists(value)) {
+      } else if (type === 'delta' && !this._fetchPolyfillPatched && checkFetchExists(value)) {
         this._fetchPolyfillPatched = true;
         original.set(key, patchFetchPolyfill(value));
       } else {

--- a/app/middlewares/delta/DeltaPatcher.js
+++ b/app/middlewares/delta/DeltaPatcher.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-import patchFetchPolyfill from './patchFetchPolyfill';
+import { checkFetchExists, patchFetchPolyfill } from './patchFetchPolyfill';
 
 /* eslint-disable no-underscore-dangle */
 
@@ -37,6 +37,7 @@ export default class DeltaPatcher {
     this._initialized = false;
     this._lastNumModifiedFiles = 0;
     this._lastModifiedDate = new Date();
+    this._fetchPolyfillPatched = false;
   }
 
   static get(id) {
@@ -60,6 +61,7 @@ export default class DeltaPatcher {
     }
 
     this._initialized = true;
+    this._fetchPolyfillPatched = false;
 
     // Reset the current delta when we receive a fresh delta.
     if (deltaBundle.reset) {
@@ -117,8 +119,11 @@ export default class DeltaPatcher {
     for (const [key, value] of patch.entries()) {
       if (value == null) {
         original.delete(key);
-      } else {
+      } else if (!this._fetchPolyfillPatched && checkFetchExists(value)) {
+        this._fetchPolyfillPatched = true;
         original.set(key, patchFetchPolyfill(value));
+      } else {
+        original.set(key, value);
       }
     }
   }

--- a/app/middlewares/delta/DeltaPatcher.js
+++ b/app/middlewares/delta/DeltaPatcher.js
@@ -7,6 +7,8 @@
  * @format
  */
 
+import patchFetchPolyfill from './patchFetchPolyfill';
+
 /* eslint-disable no-underscore-dangle */
 
 /**
@@ -116,7 +118,7 @@ export default class DeltaPatcher {
       if (value == null) {
         original.delete(key);
       } else {
-        original.set(key, value);
+        original.set(key, patchFetchPolyfill(value));
       }
     }
   }

--- a/app/middlewares/delta/patchFetchPolyfill.js
+++ b/app/middlewares/delta/patchFetchPolyfill.js
@@ -1,0 +1,17 @@
+/*
+ * See https://github.com/jhen0409/react-native-debugger/issues/209
+ *
+ * Patch whatwg-fetch code to get `support` var,
+ * so we could use it to fix the issue.
+ */
+const isFetch = '"node_modules/whatwg-fetch/fetch.js"';
+const flag = /if \(self.fetch\) {\n\s+return;\n\s+}\n\s+var support = {/g;
+const replaceStr =
+  'if (self.fetch) {\n      return;\n    }\n    var support = self._fetchSupport = {';
+
+export default function patchFetchPolyfill(code) {
+  if (code.indexOf(isFetch) === -1) {
+    return code;
+  }
+  return code.replace(flag, replaceStr);
+}

--- a/app/middlewares/delta/patchFetchPolyfill.js
+++ b/app/middlewares/delta/patchFetchPolyfill.js
@@ -9,9 +9,5 @@ const flag = /if \(self.fetch\) {\n\s+return;\n\s+}\n\s+var support = {/g;
 const replaceStr =
   'if (self.fetch) {\n      return;\n    }\n    var support = self._fetchSupport = {';
 
-export default function patchFetchPolyfill(code) {
-  if (code.indexOf(isFetch) === -1) {
-    return code;
-  }
-  return code.replace(flag, replaceStr);
-}
+export const checkFetchExists = code => code.indexOf(isFetch) > -1;
+export const patchFetchPolyfill = code => code.replace(flag, replaceStr);

--- a/app/middlewares/delta/patchFetchPolyfill.js
+++ b/app/middlewares/delta/patchFetchPolyfill.js
@@ -5,9 +5,8 @@
  * so we could use it to fix the issue.
  */
 const isFetch = '"node_modules/whatwg-fetch/fetch.js"';
-const flag = /if \(self.fetch\) {\n\s+return;\n\s+}\n\s+var support = {/g;
-const replaceStr =
-  'if (self.fetch) {\n      return;\n    }\n    var support = self._fetchSupport = {';
+const flag = /(if \(self.fetch\) {\n\s+return;\n\s+}\n\s+var support )(=)( {)/g;
+const replaceStr = '$1= self._fetchSupport =$3';
 
 export const checkFetchExists = code => code.indexOf(isFetch) > -1;
 export const patchFetchPolyfill = code => code.replace(flag, replaceStr);

--- a/app/worker/networkInspect.js
+++ b/app/worker/networkInspect.js
@@ -2,11 +2,15 @@ const isWorkerMethod = fn => String(fn).indexOf('[native code]') > -1;
 
 let networkInspect;
 
+/* eslint-disable no-underscore-dangle */
 export const toggleNetworkInspect = enabled => {
   if (!enabled && networkInspect) {
     window.XMLHttpRequest = networkInspect.XMLHttpRequest;
     window.FormData = networkInspect.FormData;
     networkInspect = null;
+    if (window._fetchSupport) {
+      window._fetchSupport.blob = !!window._fetchSupport._blob;
+    }
     return;
   }
   if (!enabled) return;
@@ -29,6 +33,13 @@ export const toggleNetworkInspect = enabled => {
     ? window.originalXMLHttpRequest
     : window.XMLHttpRequest;
   window.FormData = window.originalFormData ? window.originalFormData : window.FormData;
+
+  // Disable `support.blob` in `whatwg-fetch` for use native XMLHttpRequest,
+  // See https://github.com/jhen0409/react-native-debugger/issues/56
+  if (window._fetchSupport) {
+    window._fetchSupport._blob = window._fetchSupport.blob;
+    window._fetchSupport.blob = false;
+  }
 
   console.log(
     '[RNDebugger]',

--- a/app/worker/setup.js
+++ b/app/worker/setup.js
@@ -7,8 +7,9 @@ import {
 self.global = self;
 
 /*
- * Currently Blob is not supported for RN,
- * we should remove it in WebWorker because it will used for `whatwg-fetch`
+ * Blob is not supported for RN < 0.54,
+ * we should remove it in WebWorker because
+ * it will used for `whatwg-fetch` on older RN versions
  */
 if (self.Blob && self.Blob.toString() === 'function Blob() { [native code] }') {
   delete self.Blob;


### PR DESCRIPTION
Fix #209 with patch `whatwg-fetch` code in app bundle, so we can change [`support.blob`](https://github.com/github/fetch/blob/master/fetch.js#L11) to false if Network Inspect is on. This wouldn't affect the [`response.blob()`](https://github.com/github/fetch/blob/master/fetch.js#L241) usage because the Network Inspect will be enabled after `whatwg-fetch` imported.

It only for Delta bundler, but it is enough for RN >= 0.54. (https://github.com/facebook/react-native/commit/be56a3efeefefa6dca816ca5149a3dabfa5164e2)