### PR TITLE
set global.Blob to global.originalBlob before deleting global.Blob for rn > 0.54 compatability

### DIFF
--- a/app/worker/setup.js
+++ b/app/worker/setup.js
@@ -12,6 +12,13 @@ self.global = self;
  * it will used for `whatwg-fetch` on older RN versions
  */
 if (self.Blob && self.Blob.toString() === 'function Blob() { [native code] }') {
+  /*
+   * RN > 0.54 will polyfill Blob.
+   * If it is deleted before the RN setup, RN will not add a reference to the original.
+   * We will need to be able to restore the original when running RN > 0.54 for networking tools,
+   * so add the reference here as react-native will not do it if the original is deleted
+   */
+  self.originalBlob = self.Blob;
   delete self.Blob;
 }
 

--- a/docs/network-inspect-of-chrome-devtools.md
+++ b/docs/network-inspect-of-chrome-devtools.md
@@ -15,6 +15,12 @@ global.XMLHttpRequest = global.originalXMLHttpRequest ?
 global.FormData = global.originalFormData ?
   global.originalFormData :
   global.FormData;
+global.Blob = global.originalBlob ?
+  global.originalBlob :
+  global.Blob;
+global.FileReader = global.originalFileReader ?
+  global.originalFileReader :
+  global.FileReader;
 ```
 
 This allows you can open the `Network` tab in devtools to inspect requests of `fetch` and `XMLHttpRequest`.


### PR DESCRIPTION
this should address #245, #242 in this repo, and react-native issue [react-native#18818](https://github.com/facebook/react-native/issues/18818).  

Also I believe this is related to [whatwg-fetch#580](https://github.com/github/fetch/issues/580) 

The issue seems to be very fluid between versions of the debugger and react-native, but it specifically addresses an incompatibility between react-native-debugger@0.7.18 and react-native@0.55.4 in a way that should not break compatibility with older versions of react-native