### PR TITLE
Fix context menu functions on RN 0.57

### DIFF
--- a/app/middlewares/delta/patchFetchPolyfill.js
+++ b/app/middlewares/delta/patchFetchPolyfill.js
@@ -11,6 +11,10 @@ const isFetch = [
    * RN >= 0.56
    */
   /,"whatwg-fetch.js"\)/,
+  /*
+   * RN >= 0.57, it is now in react-native/Libraries/vendor/core/
+   */
+  /"node_modules\/react-native\/Libraries\/vendor\/core\/whatwg-fetch.js"/,
 ];
 
 const fetchSupportFlag = /(var support )(=)( {)/g;


### PR DESCRIPTION
* Fix context menu functions, the `metroRequire` function have been renamed to `__r`. ([`metro/src/lib/polyfills/require.js#L60`](https://github.com/facebook/metro/blob/master/packages/metro/src/lib/polyfills/require.js#L60))
* Fix Network Inspect (#257)