### PR TITLE
Do notify first before `autoUpdater.checkForUpdates`

### DIFF
--- a/electron/update.js
+++ b/electron/update.js
@@ -1,76 +1,83 @@
 import { app, dialog, shell } from 'electron';
 import GhReleases from 'electron-gh-releases';
+import fetch from 'electron-fetch';
+
+const repo = 'jhen0409/react-native-debugger';
+
+const getFeed = () =>
+  fetch(`https://raw.githubusercontent.com/${repo}/master/auto_updater.json`).then(res =>
+    res.json()
+  );
+
+const showDialog = ({ icon, buttons, message, detail }) =>
+  dialog.showMessageBox({
+    type: 'info',
+    buttons,
+    title: 'React Native Debugger',
+    icon,
+    message,
+    detail,
+  });
+
+const notifyUpdateAvailable = detail => {
+  const index = showDialog({
+    message: 'A newer version is available.',
+    buttons: ['Download', 'Later'],
+    detail,
+  });
+  if (index === 1) return;
+  shell.openExternal('https://github.com/jhen0409/react-native-debugger/releases');
+};
+
+const notifyRequestUpdate = detail => {
+  const index = showDialog({
+    message:
+      'The newer version has been downloaded. ' +
+      'Please restart the application to apply the update.',
+    buttons: ['Download and Restart', 'Later'],
+    detail,
+  });
+  return index === 0;
+};
 
 let checking = false;
 
 export default (icon, notify) => {
-  if (checking) {
-    console.log('[Updater] Already checking...');
-    return;
-  }
+  if (checking) return;
 
   checking = true;
   const updater = new GhReleases({
-    repo: 'jhen0409/react-native-debugger',
+    repo,
     currentVersion: app.getVersion(),
   });
 
-  updater.check((err, status) => {
+  updater.check(async (err, status) => {
     if (process.platform === 'linux' && err.message === 'This platform is not supported.') {
       err = null; // eslint-disable-line
       status = true; // eslint-disable-line
     }
     if (notify && err) {
-      dialog.showMessageBox({
-        type: 'info',
-        buttons: ['OK'],
-        title: 'React Native Debugger',
-        icon,
-        message: err.message,
-      });
-      console.log('[Updater]', err.message);
+      showDialog({ message: err.message, buttons: ['OK'] });
       checking = false;
       return;
     }
     if (err || !status) {
-      console.log('[Updater] Error', err && err.message, status);
       checking = false;
       return;
     }
+    const feed = await getFeed();
+    const detail = `${feed.name}\n\n${feed.notes}`;
     if (notify) {
-      const index = dialog.showMessageBox({
-        type: 'info',
-        buttons: ['Download', 'Later'],
-        title: 'React Native Debugger',
-        icon,
-        message: 'A newer version is available.',
-      });
-      checking = false;
-      if (index === 1) return;
-      shell.openExternal('https://github.com/jhen0409/react-native-debugger/releases');
-      console.log('[Updater] Open external link.');
-      return;
-    }
-    if (process.env.NODE_ENV === 'production' && process.platform === 'darwin') {
+      notifyUpdateAvailable(detail);
+    } else if (
+      process.env.NODE_ENV === 'production' &&
+      process.platform === 'darwin' &&
+      notifyRequestUpdate()
+    ) {
       updater.download();
-      console.log('[Updater] Starting download...');
     }
-  });
-  console.log('[Updater] Checking updates...');
-
-  updater.on('update-downloaded', ([, releaseNotes, releaseName]) => {
-    console.log('[Updater] Downloaded.');
-    const index = dialog.showMessageBox({
-      type: 'info',
-      buttons: ['Restart', 'Later'],
-      title: 'React Native Debugger',
-      icon,
-      message: 'The newer version has been downloaded. ' +
-        'Please restart the application to apply the update.',
-      detail: `${releaseName}\n\n${releaseNotes}`,
-    });
     checking = false;
-    if (index === 1) return;
-    updater.install();
   });
+
+  updater.on('update-downloaded', () => updater.install());
 };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "adbkit": "^2.11.0",
     "electron-context-menu": "jhen0409/electron-context-menu#async-popup",
+    "electron-fetch": "^1.2.1",
     "electron-gh-releases": "^2.0.4",
     "electron-store": "^1.2.0",
     "jsan": "^3.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,12 @@ electron-download@^4.0.0, electron-download@^4.1.0:
     semver "^5.3.0"
     sumchecker "^2.0.1"
 
+electron-fetch@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/electron-fetch/-/electron-fetch-1.2.1.tgz#08a033a23cc47febf05457f3e0e0a26598d02b95"
+  dependencies:
+    encoding "^0.1.12"
+
 electron-gh-releases@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/electron-gh-releases/-/electron-gh-releases-2.0.4.tgz#198c07a0970fb8e80fcc67bd0b4198a010923dc3"
@@ -2856,7 +2862,7 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:


### PR DESCRIPTION
This is fix for https://github.com/jhen0409/react-native-debugger/issues/270#issuecomment-426168729, just avoid download the update first.

It will also be shipped to `v0.7` branch.