### PR TITLE
Adds check for first query param for deltaBundleId

### DIFF
--- a/app/middlewares/delta/deltaUrlToBlobUrl.js
+++ b/app/middlewares/delta/deltaUrlToBlobUrl.js
@@ -16,9 +16,14 @@ const cachedBundleUrls = new Map();
 export default async function deltaUrlToBlobUrl(deltaUrl) {
   const client = DeltaPatcher.get(deltaUrl);
 
-  const deltaBundleId = client.getLastBundleId()
-    ? `&deltaBundleId=${client.getLastBundleId()}`
-    : '';
+  const lastBundleId = client.getLastBundleId();
+
+  const deltaBundleId = lastBundleId
+    ? `${
+        lastBundleId.indexOf("?") === -1 ? "?" : "&"
+      }deltaBundleId=${lastBundleId}`
+    : "";
+
 
   const data = await fetch(deltaUrl + deltaBundleId);
   const bundle = await data.json();

--- a/app/middlewares/delta/deltaUrlToBlobUrl.js
+++ b/app/middlewares/delta/deltaUrlToBlobUrl.js
@@ -19,10 +19,8 @@ export default async function deltaUrlToBlobUrl(deltaUrl) {
   const lastBundleId = client.getLastBundleId();
 
   const deltaBundleId = lastBundleId
-    ? `${
-        lastBundleId.indexOf("?") === -1 ? "?" : "&"
-      }deltaBundleId=${lastBundleId}`
-    : "";
+    ? `${lastBundleId.indexOf('?') === -1 ? '?' : '&'}deltaBundleId=${lastBundleId}`
+    : '';
 
 
   const data = await fetch(deltaUrl + deltaBundleId);


### PR DESCRIPTION
I've an issue where requests would be made to `http://127.0.0.1:8081/index.ios.delta&deltaBundleId=f629f67b2d9863a7` (using `&` instead of `?` for the first query param) resulting in a 404 and then a red screen whenever you reload the app after connecting to React Native Debugger. 

This PR checks if a query param already exists and instead appends a second param to bypass this issue.