### PR TITLE
Upgrade React Devtools Dependency

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "adbkit": "^2.11.0",
     "electron-store": "^1.2.0",
-    "react-devtools-core": "^3.4.0"
+    "react-devtools-core": "^3.4.3"
   },
   "optionalDependencies": {
     "electron-named-image": "^1.0.4"

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -166,9 +166,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-react-devtools-core@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.4.0.tgz#6b61594dce01b129a9e0b44b5bc4952f8f59ceec"
+react-devtools-core@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.4.3.tgz#1a06b7dc546d41ecf8dc4fbabea2d79d339353cf"
+  integrity sha512-t3f6cRH5YSKv8qjRl1Z+1e0OwBZwJSdOAhJ9QAJdVKML7SmqAKKv3DxF+Ue03pE1N2UipPsLmaNcPzzMjIdZQg==
   dependencies:
     shell-quote "^1.6.1"
     ws "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prop-types": "^15.6.1",
     "react": "^15.6.1",
     "react-dev-utils": "^4.2.1",
-    "react-devtools-core": "^3.4.0",
+    "react-devtools-core": "^3.4.3",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,9 +6890,10 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-devtools-core@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.4.0.tgz#6b61594dce01b129a9e0b44b5bc4952f8f59ceec"
+react-devtools-core@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.4.3.tgz#1a06b7dc546d41ecf8dc4fbabea2d79d339353cf"
+  integrity sha512-t3f6cRH5YSKv8qjRl1Z+1e0OwBZwJSdOAhJ9QAJdVKML7SmqAKKv3DxF+Ue03pE1N2UipPsLmaNcPzzMjIdZQg==
   dependencies:
     shell-quote "^1.6.1"
     ws "^3.3.1"


### PR DESCRIPTION
To resolve Issue #291
Using an older verison of react-native-debugger with the newest version of
react-native causes a warning bubble to appear with the content:
Warning: unknown call: "relay:check"

This patch updates to the newest react-devtools-core to resolve this.