### PR TITLE
Clarify the outcome of brew cask install on MacOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ For **macOS**, you can use [Homebrew Cask](https://caskroom.github.io) to instal
 $ brew update && brew cask install react-native-debugger
 ```
 
+This puts `React Native Debugger.app` in your `/applications/` folder.
+
 ## Documentation
 
 * [Getting Started](docs/getting-started.md)


### PR DESCRIPTION
Later in `Getting Started` it says `Make sure RNDebugger is open and wait state` and this pull request, if merged, makes doing so more obvious.