### PR TITLE
Ignore Apollo DevTools interval check for `MessageQueue.spy`

### DIFF
--- a/app/worker/apollo.js
+++ b/app/worker/apollo.js
@@ -44,4 +44,5 @@ export function handleApolloClient(modules) {
 
     initBackend(bridge, hook, getSafeAsyncStorage(modules.AsyncStorage));
   }, 1000);
+  return interval;
 }

--- a/app/worker/index.js
+++ b/app/worker/index.js
@@ -48,13 +48,12 @@ const setupRNDebugger = async message => {
   self.__RND_INTERVAL__ = setInterval(function() {}, 100); // eslint-disable-line
 
   const modules = await getRequiredModules(message.moduleSize);
+  const apolloCheckInterval = handleApolloClient(modules);
   if (modules) {
-    ignoreRNDIntervalSpy(modules);
+    ignoreRNDIntervalSpy(modules, [apolloCheckInterval]);
     checkAvailableDevMenuMethods(modules, message.networkInspect);
     reportDefaultReactDevToolsPort(modules);
   }
-
-  handleApolloClient(modules);
 };
 
 const messageHandlers = {

--- a/app/worker/utils.js
+++ b/app/worker/utils.js
@@ -83,7 +83,7 @@ export const getRequiredModules = async size => {
 const TO_JS = 0;
 const isIntervalMatch = (intervalIdList, info) =>
   info.type === TO_JS &&
-  info.module === 'JSTimersExecution' &&
+  (info.module === 'JSTimersExecution' || info.module === 'JSTimers') &&
   info.method === 'callTimers' &&
   info.args &&
   info.args[0] &&

--- a/app/worker/utils.js
+++ b/app/worker/utils.js
@@ -81,28 +81,29 @@ export const getRequiredModules = async size => {
 };
 
 const TO_JS = 0;
-const isRNDInterval = info =>
+const isIntervalMatch = (intervalIdList, info) =>
   info.type === TO_JS &&
   info.module === 'JSTimersExecution' &&
   info.method === 'callTimers' &&
   info.args &&
   info.args[0] &&
-  info.args[0][0] === self.__RND_INTERVAL__;
+  intervalIdList.includes(info.args[0][0]);
 
-export const ignoreRNDIntervalSpy = async ({ MessageQueue }) => {
+export const ignoreRNDIntervalSpy = async ({ MessageQueue }, intervals = []) => {
   if (MessageQueue.__empty) return;
   // Wrap spy function if it already set
+  const intervalIdList = [self.__RND_INTERVAL__].concat(intervals);
   if (MessageQueue.prototype.__spy) {
     const originalSpyFn = MessageQueue.prototype.__spy;
     MessageQueue.prototype.__spy = info => {
-      if (isRNDInterval(info)) return;
+      if (isIntervalMatch(intervalIdList, info)) return;
       return originalSpyFn(info);
     };
   }
   MessageQueue.spy = spyOrToggle => {
     if (spyOrToggle === true) {
       MessageQueue.prototype.__spy = info => {
-        if (isRNDInterval(info)) return;
+        if (isIntervalMatch(intervalIdList, info)) return;
         console.log(
           `${info.type === TO_JS ? 'N->JS' : 'JS->N'} : ` +
             `${info.module ? `${info.module}.` : ''}${info.method}` +
@@ -113,7 +114,7 @@ export const ignoreRNDIntervalSpy = async ({ MessageQueue }) => {
       MessageQueue.prototype.__spy = null;
     } else {
       MessageQueue.prototype.__spy = info => {
-        if (isRNDInterval(info)) return;
+        if (isIntervalMatch(intervalIdList, info)) return;
         return spyOrToggle(info);
       };
     }


### PR DESCRIPTION
Currently the Apollo DevTools interval check will affect we using `MessageQueue.spy` to debug message queue changes.