### PR TITLE
Enable performance tab in production build.

### DIFF
--- a/electron/devtools.js
+++ b/electron/devtools.js
@@ -47,7 +47,6 @@ export const removeUnecessaryTabs = win => {
       if (tabbedPane) {
         tabbedPane.closeTab('elements');
         tabbedPane.closeTab('security');
-        tabbedPane.closeTab('timeline'); // Performance
         tabbedPane.closeTab('audits');
 
         tabbedPane._leftToolbar._contentElement.remove();


### PR DESCRIPTION
#199.

I've tried out performance tab. Everything seems to work, since it also inspects the web worker.

People suggest to use react profiler (didn't even know that it exists) but the performance tab displays more info, not only react related.

Are there any drawbacks for having it in production build?