### PR TITLE
Remove origin header on network calls.

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -91,6 +91,7 @@ app.on('ready', async () => {
         delete details.requestHeaders[header];
       }
     });
+    delete details.requestHeaders.Origin;
     callback({ cancel: false, requestHeaders: details.requestHeaders });
   });
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -84,6 +84,7 @@ app.on('ready', async () => {
 
   const replaceHeaderPrefix = '__RN_DEBUGGER_SET_HEADER_REQUEST_';
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    delete details.requestHeaders.Origin;
     Object.entries(details.requestHeaders).forEach(([header, value]) => {
       if (header.startsWith(replaceHeaderPrefix)) {
         const originalHeader = header.replace(replaceHeaderPrefix, '');
@@ -91,7 +92,6 @@ app.on('ready', async () => {
         delete details.requestHeaders[header];
       }
     });
-    delete details.requestHeaders.Origin;
     callback({ cancel: false, requestHeaders: details.requestHeaders });
   });
 });


### PR DESCRIPTION
#296 

Since electron always adds null Origin header (https://github.com/electron/electron/issues/7931) I've added removal of Origin header in onBeforeSendHeaders.

Maybe we should only remove the header if the header is "null"? But I don't think you can control this header manually in RND.