### PR TITLE
RN 0.59: Avoid AsyncStorage warning by re-wrap the native module

### DIFF
--- a/app/worker/apollo.js
+++ b/app/worker/apollo.js
@@ -3,7 +3,7 @@ import { initBackend, sendBridgeReady } from 'apollo-client-devtools/src/backend
 import { version as devToolsVersion } from 'apollo-client-devtools/package.json';
 import { getSafeAsyncStorage } from './asyncStorage';
 
-export function handleApolloClient({ AsyncStorage } = {}) {
+export function handleApolloClient({ NativeModules } = {}) {
   const interval = setInterval(() => {
     if (!self.__APOLLO_CLIENT__) {
       return;
@@ -42,7 +42,7 @@ export function handleApolloClient({ AsyncStorage } = {}) {
       self.removeEventListener('message', listener);
     });
 
-    initBackend(bridge, hook, getSafeAsyncStorage(AsyncStorage));
+    initBackend(bridge, hook, getSafeAsyncStorage(NativeModules));
   }, 1000);
   return interval;
 }

--- a/app/worker/asyncStorage.js
+++ b/app/worker/asyncStorage.js
@@ -3,22 +3,86 @@ export const getClearAsyncStorageFn = AsyncStorage => {
   return () => AsyncStorage.clear().catch(f => f);
 };
 
-export const getSafeAsyncStorage = AsyncStorage => ({
-  async getItem(key) {
-    try {
-      return AsyncStorage.getItem(key);
-    } catch (e) {
-      return null;
-    }
-  },
-  async setItem(key, value) {
-    try {
-      return AsyncStorage.setItem(key, value);
-    } catch (e) {
-      return null;
-    }
-  },
-});
+function convertError(error): ?Error {
+  if (!error) {
+    return null;
+  }
+  const out = new Error(error.message);
+  out.key = error.key;
+  return out;
+}
+
+function convertErrors(errs) {
+  if (!errs) {
+    return null;
+  }
+  return (Array.isArray(errs) ? errs : [errs]).map(e => convertError(e));
+}
+
+export const getSafeAsyncStorage = NativeModules => {
+  // Use RocksDB if available, then SQLite, then file storage.
+  // Changed Name of SQLite DB, to not conflict with AsyncStorage from RN repo
+  const RCTAsyncStorage =
+    NativeModules &&
+    (NativeModules.AsyncRocksDBStorage ||
+      NativeModules.RNC_AsyncSQLiteDBStorage ||
+      NativeModules.AsyncLocalStorage);
+
+  return {
+    getItem(key) {
+      if (!RCTAsyncStorage) return Promise.resolve(null);
+      return new Promise((resolve, reject) => {
+        RCTAsyncStorage.multiGet([key], (errors, result) => {
+          // Unpack result to get value from [[key,value]]
+          const value = result && result[0] && result[0][1] ? result[0][1] : null;
+          const errs = convertErrors(errors);
+          if (errs) {
+            reject(errs[0]);
+          } else {
+            resolve(value);
+          }
+        });
+      });
+    },
+    async setItem(key, value) {
+      if (!RCTAsyncStorage) return Promise.resolve(null);
+      return new Promise((resolve, reject) => {
+        RCTAsyncStorage.multiSet([[key, value]], errors => {
+          const errs = convertErrors(errors);
+          if (errs) {
+            reject(errs[0]);
+          } else {
+            resolve(null);
+          }
+        });
+      });
+    },
+    clear() {
+      if (!RCTAsyncStorage) return Promise.resolve(null);
+      return new Promise((resolve, reject) => {
+        RCTAsyncStorage.clear(error => {
+          if (error && convertError(error)) {
+            reject(convertError(error));
+          } else {
+            resolve(null);
+          }
+        });
+      });
+    },
+    getAllKeys() {
+      if (!RCTAsyncStorage) return Promise.resolve(null);
+      return new Promise((resolve, reject) => {
+        RCTAsyncStorage.getAllKeys((error, keys) => {
+          if (error) {
+            reject(convertError(error));
+          } else {
+            resolve(keys);
+          }
+        });
+      });
+    },
+  };
+};
 
 export const getShowAsyncStorageFn = AsyncStorage => {
   if (!AsyncStorage.getAllKeys || !AsyncStorage.getItem) return;

--- a/app/worker/devMenu.js
+++ b/app/worker/devMenu.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 
 import { toggleNetworkInspect } from './networkInspect';
-import { getClearAsyncStorageFn, getShowAsyncStorageFn } from './asyncStorage';
+import { getClearAsyncStorageFn, getShowAsyncStorageFn, getSafeAsyncStorage } from './asyncStorage';
 
 let availableDevMenuMethods = {};
 
 export const checkAvailableDevMenuMethods = async (
-  { NativeModules, AsyncStorage },
+  { NativeModules },
   enableNetworkInspect = false
 ) => {
   // RN 0.43 use DevSettings, DevMenu will be deprecated
@@ -17,6 +17,7 @@ export const checkAvailableDevMenuMethods = async (
     (NativeModules.DevMenu && NativeModules.DevMenu.show) ||
     undefined;
 
+  const AsyncStorage = getSafeAsyncStorage(NativeModules);
   const methods = {
     ...DevSettings,
     show: showDevMenu,


### PR DESCRIPTION
Since we used AsyncStorage to made context menu functions of RNDebugger, it caused the warning in RN ^0.59:

```
ExceptionsManager.js:82 Warning: Async Storage has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/async-storage' instead of 'react-native'. See https://github.com/react-native-community/react-native-async-storage
```

Just use `NativeModules` to re-wrap the module to avoid the warning. It also fixes the issue of AsyncStorage functions of context menu in future RN versions.