### PR TITLE
Fixed: `predicate` option of the redux devtool is not used

### DIFF
--- a/__e2e__/app.spec.js
+++ b/__e2e__/app.spec.js
@@ -254,7 +254,8 @@ describe('Application launch', () => {
         notExpt: [
           /TEST_PASS_FOR_REDUX_STORE_1/,
           /NOT_SHOW_1_FOR_REDUX_STORE_2/,
-          /NOT_SHOW_1_FOR_REDUX_STORE_2/,
+          /NOT_SHOW_2_FOR_REDUX_STORE_2/,
+          /NOT_SHOW_3_FOR_REDUX_STORE_2/,
         ],
       },
       'MobX store instance 1': {

--- a/__e2e__/fixture/redux.js
+++ b/__e2e__/fixture/redux.js
@@ -20,9 +20,7 @@ export default function run() {
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
       name: 'Redux store instance 2',
       actionsBlacklist: ['NOT_SHOW_1_FOR_REDUX_STORE_2', 'NOT_SHOW_2_FOR_REDUX_STORE_2'],
-      predicate: (state, action) => {
-        return action.type !== 'NOT_SHOW_3_FOR_REDUX_STORE_2';
-      }
+      predicate: (state, action) => action.type !== 'NOT_SHOW_3_FOR_REDUX_STORE_2',
     })(/* No enhancers */)
   );
 

--- a/__e2e__/fixture/redux.js
+++ b/__e2e__/fixture/redux.js
@@ -20,6 +20,9 @@ export default function run() {
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
       name: 'Redux store instance 2',
       actionsBlacklist: ['NOT_SHOW_1_FOR_REDUX_STORE_2', 'NOT_SHOW_2_FOR_REDUX_STORE_2'],
+      predicate: (state, action) => {
+        return action.type !== 'NOT_SHOW_3_FOR_REDUX_STORE_2';
+      }
     })(/* No enhancers */)
   );
 
@@ -30,4 +33,5 @@ export default function run() {
   store2.dispatch({ type: 'TEST_PASS_FOR_REDUX_STORE_2' });
   store2.dispatch({ type: 'NOT_SHOW_1_FOR_REDUX_STORE_2' });
   store2.dispatch({ type: 'NOT_SHOW_2_FOR_REDUX_STORE_2' });
+  store2.dispatch({ type: 'NOT_SHOW_3_FOR_REDUX_STORE_2' });
 }

--- a/app/worker/reduxAPI.js
+++ b/app/worker/reduxAPI.js
@@ -199,6 +199,7 @@ function handleChange(state, liftedState, maxAge, instance) {
     const nextActionId = liftedState.nextActionId;
     const liftedAction = liftedState.actionsById[nextActionId - 1];
     if (isFiltered(liftedAction.action, filters)) return;
+    if (predicate && !predicate(state, liftedAction.action)) return;
     relay('ACTION', state, instance, liftedAction, nextActionId);
     if (!isExcess && maxAge) isExcess = liftedState.stagedActionIds.length >= maxAge;
   } else {

--- a/app/worker/reduxAPI.js
+++ b/app/worker/reduxAPI.js
@@ -194,7 +194,7 @@ function monitorReducer(state = {}, action) {
 function handleChange(state, liftedState, maxAge, instance) {
   if (checkForReducerErrors(liftedState, instance)) return;
 
-  const { filters } = instance;
+  const { filters, predicate } = instance;
   if (lastAction === 'PERFORM_ACTION') {
     const nextActionId = liftedState.nextActionId;
     const liftedAction = liftedState.actionsById[nextActionId - 1];


### PR DESCRIPTION
Fixed: [`predicate` option](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#predicate) of the redux devtool is not used.


