### PR TITLE
Add timesJSLoadToRefreshDevTools config option

### DIFF
--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -124,24 +124,24 @@ const flushQueuedMessages = () => {
   queuedMessages = [];
 };
 
-let reloadCount = 0;
-const checkJSReloadCount = () => {
-  reloadCount++;
+let loadCount = 0;
+const checkJSLoadCount = () => {
+  loadCount++;
   if (
     currentWindow.webContents.isDevToolsOpened() &&
     config.timesJSLoadToRefreshDevTools >= 0 &&
-    reloadCount > 0 &&
-    reloadCount % config.timesJSLoadToRefreshDevTools === 0
+    loadCount > 0 &&
+    loadCount % config.timesJSLoadToRefreshDevTools === 0
   ) {
     currentWindow.webContents.closeDevTools();
     currentWindow.webContents.openDevTools();
     console.warn(
       '[RNDebugger]',
-      `Refreshed the devtools panel as React Native app was reloaded ${reloadCount} times.`,
+      `Refreshed the devtools panel as React Native app was reloaded ${loadCount} times.`,
       'If you want to update or disable this,',
       'Open `Debugger` -> `Open Config File` to change `timesJSLoadToRefreshDevTools` field.'
     );
-    reloadCount = 0;
+    loadCount = 0;
   }
 };
 
@@ -189,6 +189,7 @@ const connectToDebuggerProxy = async () => {
             scriptExecuted = true;
             worker.postMessage({ ...object, url });
             flushQueuedMessages();
+            checkJSLoadCount();
             return;
           }
         } finally {
@@ -196,7 +197,7 @@ const connectToDebuggerProxy = async () => {
           clearLogs();
           scriptExecuted = true;
         }
-        checkJSReloadCount();
+        checkJSLoadCount();
       }
       if (scriptExecuted) {
         // Otherwise, pass through to the worker provided the

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -126,6 +126,7 @@ const flushQueuedMessages = () => {
 
 let reloadCount = 0;
 const checkJSReloadCount = () => {
+  reloadCount++;
   if (
     currentWindow.webContents.isDevToolsOpened() &&
     config.timesJSReloadToRefreshDevTools >= 0 &&
@@ -141,8 +142,6 @@ const checkJSReloadCount = () => {
       'Open `Debugger` -> `Open Config File` to change `timesJSReloadToRefreshDevTools` field.'
     );
     reloadCount = 0;
-  } else {
-    reloadCount++;
   }
 };
 

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -134,6 +134,12 @@ const checkJSReloadCount = () => {
   ) {
     currentWindow.webContents.closeDevTools();
     currentWindow.webContents.openDevTools();
+    console.warn(
+      '[RNDebugger]',
+      `Refreshed the devtools panel as React Native app was reloaded ${reloadCount} times.`,
+      'If you want to update or disable this,',
+      'Open `Debugger` -> `Open Config File` to change `timesJSReloadToRefreshDevTools` field.'
+    );
     reloadCount = 0;
   } else {
     reloadCount++;
@@ -167,7 +173,6 @@ const connectToDebuggerProxy = async () => {
     } else {
       if (!worker) return;
       if (object.method === 'executeApplicationScript') {
-        checkJSReloadCount();
         object.networkInspect = networkInspect.isEnabled();
         object.reactDevToolsPort = window.reactDevToolsPort;
         if (isScriptBuildForAndroid(object.url)) {
@@ -192,6 +197,7 @@ const connectToDebuggerProxy = async () => {
           clearLogs();
           scriptExecuted = true;
         }
+        checkJSReloadCount();
       }
       if (scriptExecuted) {
         // Otherwise, pass through to the worker provided the

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -129,9 +129,9 @@ const checkJSReloadCount = () => {
   reloadCount++;
   if (
     currentWindow.webContents.isDevToolsOpened() &&
-    config.timesJSReloadToRefreshDevTools >= 0 &&
+    config.timesJSLoadToRefreshDevTools >= 0 &&
     reloadCount > 0 &&
-    reloadCount % config.timesJSReloadToRefreshDevTools === 0
+    reloadCount % config.timesJSLoadToRefreshDevTools === 0
   ) {
     currentWindow.webContents.closeDevTools();
     currentWindow.webContents.openDevTools();
@@ -139,7 +139,7 @@ const checkJSReloadCount = () => {
       '[RNDebugger]',
       `Refreshed the devtools panel as React Native app was reloaded ${reloadCount} times.`,
       'If you want to update or disable this,',
-      'Open `Debugger` -> `Open Config File` to change `timesJSReloadToRefreshDevTools` field.'
+      'Open `Debugger` -> `Open Config File` to change `timesJSLoadToRefreshDevTools` field.'
     );
     reloadCount = 0;
   }

--- a/app/middlewares/debuggerAPI.js
+++ b/app/middlewares/debuggerAPI.js
@@ -127,7 +127,7 @@ const flushQueuedMessages = () => {
 let reloadCount = 0;
 const checkJSReloadCount = () => {
   if (
-    currentWindow.webContents.isDevToolsOpened &&
+    currentWindow.webContents.isDevToolsOpened() &&
     config.timesJSReloadToRefreshDevTools >= 0 &&
     reloadCount > 0 &&
     reloadCount % config.timesJSReloadToRefreshDevTools === 0

--- a/docs/config-file-in-home-directory.md
+++ b/docs/config-file-in-home-directory.md
@@ -47,6 +47,10 @@ We could configure RNDebugger app in `~/.rndebuggerrc`, the file used [json5](ht
   // Enable Network Inspect by default
   // See https://github.com/jhen0409/react-native-debugger/blob/master/docs/network-inspect-of-chrome-devtools.md
   defaultNetworkInspect: false,
+
+  // Refresh devtools when doing JS reload every N times (-1 for disabled)
+  // This can effectively avoid possible memory leaks in devtools
+  timesJSReloadToRefreshDevTools: -1,
 }
 ```
 

--- a/docs/config-file-in-home-directory.md
+++ b/docs/config-file-in-home-directory.md
@@ -48,8 +48,9 @@ We could configure RNDebugger app in `~/.rndebuggerrc`, the file used [json5](ht
   // See https://github.com/jhen0409/react-native-debugger/blob/master/docs/network-inspect-of-chrome-devtools.md
   defaultNetworkInspect: false,
 
-  // Refresh devtools when doing JS reload every N times (-1 for disabled)
-  // This can effectively avoid possible memory leaks in devtools
+  // Refresh devtools when doing JS reload every N times. (-1 for disabled)
+  // This can effectively avoid possible memory leaks (Like
+  // https://github.com/jhen0409/react-native-debugger/issues/405) in devtools.
   timesJSReloadToRefreshDevTools: -1,
 }
 ```

--- a/docs/config-file-in-home-directory.md
+++ b/docs/config-file-in-home-directory.md
@@ -51,7 +51,7 @@ We could configure RNDebugger app in `~/.rndebuggerrc`, the file used [json5](ht
   // Refresh devtools when doing JS reload every N times. (-1 for disabled)
   // This can effectively avoid possible memory leaks (Like
   // https://github.com/jhen0409/react-native-debugger/issues/405) in devtools.
-  timesJSReloadToRefreshDevTools: -1,
+  timesJSLoadToRefreshDevTools: -1,
 }
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ Before:
 After:  
 <img width="704" alt="2017-09-19 5 41 27 pm" src="https://user-images.githubusercontent.com/3001525/30586302-29e0b268-9cf5-11e7-9206-e222bd753aa1.png">
 
-To avoid similar problems in the future, there is a way to restart the Chrome devtools (macOS: `CMD+OPTION+I`, Linux/Windows: `CTRL+ALT+I`), the same applies to official remote debugger on Chrome.
+To avoid similar problems in the future, there is a way to restart the Chrome devtools (macOS: `CMD+OPTION+I`, Linux/Windows: `CTRL+ALT+I`), the same applies to official remote debugger on Chrome. You can also consider to use [`timesJSLoadToRefreshDevTools` option in Config file in home directory](config-file-in-home-directory.md).
 
 ## [iOS] Debugger can't load bundle when I use real device
 
@@ -50,10 +50,6 @@ Also, sometimes it have timer problem between host machine and device (emulator)
 <img width="300" alt="2017-07-18 10 09 01" src="https://user-images.githubusercontent.com/3001525/28492059-3c6957ea-6f2e-11e7-8901-8f4431f67a71.png">
 
 Or try to restart your device (emulator).
-
-## Console thrown a lot of errors when I use React Inspector on Android
-
-If you're experiencing the issue like [this comment of #84](https://github.com/jhen0409/react-native-debugger/issues/84#issuecomment-304611817), this issue have been fixed in `react-devtools-core@^2.3.0`, please ensure the version is correct in your React Native project (Note that it's dependency of `react-native`).
 
 ## Other documentations
 

--- a/electron/config/__tests__/__snapshots__/index.test.js.snap
+++ b/electron/config/__tests__/__snapshots__/index.test.js.snap
@@ -11,6 +11,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
+    "timesJSReloadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },
@@ -29,6 +30,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
+    "timesJSReloadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },
@@ -55,6 +57,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
+    "timesJSReloadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },

--- a/electron/config/__tests__/__snapshots__/index.test.js.snap
+++ b/electron/config/__tests__/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
-    "timesJSReloadToRefreshDevTools": -1,
+    "timesJSLoadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },
@@ -30,7 +30,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
-    "timesJSReloadToRefreshDevTools": -1,
+    "timesJSLoadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },
@@ -57,7 +57,7 @@ Object {
     "defaultReactDevToolsPort": 19567,
     "defaultReactDevToolsTheme": "RNDebugger",
     "editor": "",
-    "timesJSReloadToRefreshDevTools": -1,
+    "timesJSLoadToRefreshDevTools": -1,
     "windowBounds": Object {
       "frame": true,
     },

--- a/electron/config/template.js
+++ b/electron/config/template.js
@@ -45,8 +45,9 @@ module.exports = `{
   // See https://github.com/jhen0409/react-native-debugger/blob/master/docs/network-inspect-of-chrome-devtools.md
   defaultNetworkInspect: false,
 
-  // Refresh devtools when doing JS reload every N times (-1 for disabled)
-  // This can effectively avoid possible memory leaks in devtools
+  // Refresh devtools when doing JS reload every N times. (-1 for disabled)
+  // This can effectively avoid possible memory leaks (Like
+  // https://github.com/jhen0409/react-native-debugger/issues/405) in devtools.
   timesJSReloadToRefreshDevTools: -1,
 }
 `;

--- a/electron/config/template.js
+++ b/electron/config/template.js
@@ -44,5 +44,9 @@ module.exports = `{
   // Enable Network Inspect by default
   // See https://github.com/jhen0409/react-native-debugger/blob/master/docs/network-inspect-of-chrome-devtools.md
   defaultNetworkInspect: false,
+
+  // Refresh devtools when doing JS reload every N times (-1 for disabled)
+  // This can effectively avoid possible memory leaks in devtools
+  timesJSReloadToRefreshDevTools: -1,
 }
 `;

--- a/electron/config/template.js
+++ b/electron/config/template.js
@@ -48,6 +48,6 @@ module.exports = `{
   // Refresh devtools when doing JS reload every N times. (-1 for disabled)
   // This can effectively avoid possible memory leaks (Like
   // https://github.com/jhen0409/react-native-debugger/issues/405) in devtools.
-  timesJSReloadToRefreshDevTools: -1,
+  timesJSLoadToRefreshDevTools: -1,
 }
 `;

--- a/electron/window.js
+++ b/electron/window.js
@@ -96,6 +96,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
   });
   const isFirstWindow = BrowserWindow.getAllWindows().length === 1;
 
+  const { timesJSReloadToRefreshDevTools = -1 } = config;
   win.debuggerConfig = {
     port,
     editor: config.editor,
@@ -104,6 +105,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
     defaultReactDevToolsPort: config.defaultReactDevToolsPort,
     networkInspect: config.defaultNetworkInspect && 1,
     isPortSettingRequired: isPortSettingRequired && 1,
+    timesJSReloadToRefreshDevTools,
   };
   win.loadURL(`file://${path.resolve(__dirname)}/app.html`);
   win.webContents.on('did-finish-load', () => {

--- a/electron/window.js
+++ b/electron/window.js
@@ -3,6 +3,7 @@ import { BrowserWindow, Menu, globalShortcut, dialog } from 'electron';
 import Store from 'electron-store';
 import autoUpdate from './update';
 import { catchConsoleLogLink, removeUnecessaryTabs } from './devtools';
+import { selectRNDebuggerWorkerContext } from '../app/utils/devtools';
 import { readConfig, filePath as configFile } from './config';
 
 const store = new Store();
@@ -126,6 +127,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
     if (config.showAllDevToolsTab !== true) {
       removeUnecessaryTabs(win);
     }
+    selectRNDebuggerWorkerContext(win);
   });
   win.on('show', () => {
     if (!win.isFocused()) return;

--- a/electron/window.js
+++ b/electron/window.js
@@ -97,7 +97,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
   });
   const isFirstWindow = BrowserWindow.getAllWindows().length === 1;
 
-  const { timesJSReloadToRefreshDevTools = -1 } = config;
+  const { timesJSLoadToRefreshDevTools = -1 } = config;
   win.debuggerConfig = {
     port,
     editor: config.editor,
@@ -106,7 +106,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
     defaultReactDevToolsPort: config.defaultReactDevToolsPort,
     networkInspect: config.defaultNetworkInspect && 1,
     isPortSettingRequired: isPortSettingRequired && 1,
-    timesJSReloadToRefreshDevTools,
+    timesJSLoadToRefreshDevTools,
   };
   win.loadURL(`file://${path.resolve(__dirname)}/app.html`);
   win.webContents.on('did-finish-load', () => {


### PR DESCRIPTION
Related #151 and #405.

I add the `timesJSLoadToRefreshDevTools` config option, it will refresh devtools when doing JS reload every N times (-1 for disabled). This can effectively avoid possible memory leaks in devtools. (See [`Config file in home directory`](https://github.com/jhen0409/react-native-debugger/blob/refresh-devtools-on-reload/docs/config-file-in-home-directory.md))

This is a compromise for solving the DevTools memory leak issue. Since it affects the use of devtools, it is disabled by default.