### PR TITLE
fix resolution of AsyncStorage (#435)

### DIFF
--- a/app/worker/asyncStorage.js
+++ b/app/worker/asyncStorage.js
@@ -20,14 +20,11 @@ function convertErrors(errs) {
 }
 
 export const getSafeAsyncStorage = NativeModules => {
-  // Use RocksDB if available, then SQLite, then file storage.
-  // Changed Name of SQLite DB, to not conflict with AsyncStorage from RN repo
   const RCTAsyncStorage =
     NativeModules &&
-    (NativeModules.AsyncRocksDBStorage ||
-      NativeModules.RNC_AsyncSQLiteDBStorage ||
-      NativeModules.AsyncSQLiteDBStorage ||
-      NativeModules.AsyncLocalStorage);
+    (NativeModules.RNC_AsyncSQLiteDBStorage ||
+      NativeModules.RNCAsyncStorage ||
+      NativeModules.PlatformLocalStorage);
 
   return {
     getItem(key) {
@@ -35,7 +32,8 @@ export const getSafeAsyncStorage = NativeModules => {
       return new Promise((resolve, reject) => {
         RCTAsyncStorage.multiGet([key], (errors, result) => {
           // Unpack result to get value from [[key,value]]
-          const value = result && result[0] && result[0][1] ? result[0][1] : null;
+          const value =
+            result && result[0] && result[0][1] ? result[0][1] : null;
           const errs = convertErrors(errors);
           if (errs) {
             reject(errs[0]);
@@ -90,7 +88,9 @@ export const getShowAsyncStorageFn = AsyncStorage => {
   return async () => {
     const keys = await AsyncStorage.getAllKeys();
     if (keys && keys.length) {
-      const items = await Promise.all(keys.map(key => AsyncStorage.getItem(key)));
+      const items = await Promise.all(
+        keys.map(key => AsyncStorage.getItem(key)),
+      );
       const table = {};
       keys.forEach((key, index) => (table[key] = { content: items[index] }));
       console.table(table);

--- a/app/worker/asyncStorage.js
+++ b/app/worker/asyncStorage.js
@@ -24,7 +24,10 @@ export const getSafeAsyncStorage = NativeModules => {
     NativeModules &&
     (NativeModules.RNC_AsyncSQLiteDBStorage ||
       NativeModules.RNCAsyncStorage ||
-      NativeModules.PlatformLocalStorage);
+      NativeModules.PlatformLocalStorage ||
+      NativeModules.AsyncRocksDBStorage ||
+      NativeModules.AsyncSQLiteDBStorage ||
+      NativeModules.AsyncLocalStorage);
 
   return {
     getItem(key) {


### PR DESCRIPTION
the resolution now matches the resolution of the  @react-native-community/async-storage package.

@jhen0409, this includes the fix I suggested in #435. But while it works, we simply replicate the logic of the async-storage-lib. Is there a way to e.g. do something like this:
```javascript
const RNAsyncStorage = require('@react-native-community/async-storage') || require('react-native')
```
This obviously does not work, but illustrates my point. It would make maintaining this part of the debugger probably a bit easier. 

Anyway, thanks for welcoming my pull request. I hope this helps.