### PR TITLE
[Experiment] Add xstate-devtools

### DIFF
--- a/electron/extensions.js
+++ b/electron/extensions.js
@@ -1,25 +1,38 @@
 import path from 'path';
 import { BrowserWindow } from 'electron';
+import installer, {
+  REACT_DEVELOPER_TOOLS,
+  REDUX_DEVTOOLS,
+} from 'electron-devtools-installer';
+
+const extensions = ['aamnodipnlopbknpklfoabalmobheehc'];
 
 export default async () => {
   if (process.env.NODE_ENV === 'development') {
-    const installer = require('electron-devtools-installer'); // eslint-disable-line
-
-    const extensions = ['REACT_DEVELOPER_TOOLS', 'REDUX_DEVTOOLS'];
-    const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
-    for (const name of extensions) {
-      try {
-        await installer.default(installer[name], forceDownload);
-      } catch (e) {} // eslint-disable-line
-    }
     BrowserWindow.addDevToolsExtension(path.resolve('dist/devtools-helper/'));
     BrowserWindow.addDevToolsExtension(
-      path.join(__dirname, '../node_modules/apollo-client-devtools/shells/webextension/')
+      path.join(
+        __dirname,
+        '../node_modules/apollo-client-devtools/shells/webextension/',
+      ),
     );
+    extensions.push(REACT_DEVELOPER_TOOLS);
+    extensions.push(REDUX_DEVTOOLS);
   } else {
-    BrowserWindow.addDevToolsExtension(path.join(__dirname, 'devtools-helper/'));
     BrowserWindow.addDevToolsExtension(
-      path.join(__dirname, 'node_modules/apollo-client-devtools/shells/webextension/')
+      path.join(__dirname, 'devtools-helper/'),
     );
+    BrowserWindow.addDevToolsExtension(
+      path.join(
+        __dirname,
+        'node_modules/apollo-client-devtools/shells/webextension/',
+      ),
+    );
+  }
+  const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
+  for (const ext of extensions) {
+    try {
+      await installer(ext, forceDownload);
+    } catch (e) {} // eslint-disable-line
   }
 };


### PR DESCRIPTION
This PR is integration for [`xstate-devtools`](https://github.com/amitnovick/xstate-devtools) browser extension (https://github.com/statecharts/xstate-viz/issues/30). Implemented in a simple way like #298. 

The XState core is used [`__REDUX_DEVTOOLS_EXTENSION__.connect`](https://github.com/davidkpiano/xstate/blob/a12c1a4a2cf2bf5ab78ce952f086d8835ccf9637/packages/core/src/interpreter.ts#L1177), so it have simple logging feature with `redux-devtools`. The `xstate-devtools` wrapped the method and provided `machine` argument.

For RNDebugger specificity, I added `useXStateViz` devTools option, allows users to choose simple logging on `redux-devtools` or the visualizer of `xstate-devtools`.

```js
import { useMachine } from '@xstate/react'

const [current, send] = useMachine(toggleMachine, {
  devTools: { useXStateViz: true },
})
```

I think the final goal will be integrate `xstate-viz` into [`redux-devtools-core`](https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-core), it can be made more features that `redux-devtools-extension` has.