### PR TITLE
Improve the Network Inspect documentation

### DIFF
--- a/docs/config-file-in-home-directory.md
+++ b/docs/config-file-in-home-directory.md
@@ -1,6 +1,7 @@
 # Config file in home directory
 
-We could configure RNDebugger app in `~/.rndebuggerrc`, the file used [json5](https://github.com/json5/json5) as format, see the following default template:
+We could configure RNDebugger app in `~/.rndebuggerrc` (the config can be opened from the main menu: Debugger → Open Config File), the file used [json5](https://github.com/json5/json5) as format, see the following default template:
+
 
 ```json5
 {

--- a/docs/network-inspect-of-chrome-devtools.md
+++ b/docs/network-inspect-of-chrome-devtools.md
@@ -2,7 +2,13 @@
 
 **_WARNING_**: You should read [the limitations](#limitations) if you want to use this feature.
 
-You can enable this feature by the [context menu or Touch Bar](shortcut-references.md), then you can inspect network requests that use `XMLHttpRequest` or `fetch` on the `Network` tab of Chrome Developer Tools.
+When you have Network Inspect enabled you can inspect network requests that use `XMLHttpRequest` or `fetch` on the `Network` tab of Chrome Developer Tools.
+
+You can enable this feature by one of these ways:
+ 
+ - [context menu or Touch Bar](shortcut-references.md) (Network Inspect will be enabled while the RNDebugger is running, after closing it will reset to the default value);
+ - by the `defaultNetworkInspect` option in the [config file](config-file-in-home-directory.md) (Network Inspect will be enabled permanently).
+
 
 ## How it works
 


### PR DESCRIPTION
Hi,

We face the hassles constantly in our team with explaining to newcomers how to enable Network Inspect permanently in the config file.

The changes are aimed to mitigate this problem.