### PR TITLE
Fix runtime error when opening a window with empty Electron config

### DIFF
--- a/electron/window.js
+++ b/electron/window.js
@@ -81,7 +81,7 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
     height: height && height >= minSize ? height : 750,
     minWidth: minSize,
     minHeight: minSize,
-    ...(increasePosition && winBounds.x && winBounds.y
+    ...(increasePosition && winBounds && winBounds.x && winBounds.y
       ? {
         x: winBounds.x + increasePosition,
         y: winBounds.y + increasePosition,


### PR DESCRIPTION
The `winBounds` object can be `undefined` when the electron-store config is empty. When I try to open a new window at the first launching of React Native Debugger, it reproduces the following error.

```
A JavaScript error occurred in the main process

Uncaught Exception:
TypeError: Cannot read property 'x' of undefined
    at Ee (/Applications/React Native Debugger.app/Contents/Resources/app.asar/main.js:2:252980)
    at /Applications/React Native Debugger.app/Contents/Resources/app.asar/main.js:10:2608
    at MenuItem.click (electron/js2c/browser_init.js:1513:9)
    at Function.executeCommand (electron/js2c/browser_init.js:1774:13)
```

This PR fixes #252 