### PR TITLE
Add more message for DevTools v3 incompatible message

### DIFF
--- a/scripts/patch-modules.js
+++ b/scripts/patch-modules.js
@@ -5,10 +5,17 @@ console.log('Patch react-devtools-core');
 
 const rdStandalone = path.join(
   __dirname,
-  '../dist/node_modules/react-devtools-core/build/standalone.js'
+  '../dist/node_modules/react-devtools-core/build/standalone.js',
 );
 // Hide source map of react-devtools-core
 // for optimize chrome devtools
+shell.sed(
+  '-i',
+  'DevTools v3 is incompatible with this version of React',
+  'DevTools v3 is incompatible with this version of React' +
+    ', you need manually upgrade React Native Debugger to v0.11. (Please visit the Release page)',
+  rdStandalone,
+);
 shell.sed('-i', '//# sourceMappingURL=standalone.js.map', '', rdStandalone);
 // Avoid logging from react-devtools-core
 // log: connected, disconnected
@@ -18,7 +25,7 @@ shell.sed(
   // eslint-disable-next-line
   /\(_console[0-9]* = console\).(log|warn|error).apply\(_console[0-9]*, \[ "\[React DevTools\]" \].concat\(args\)\)/,
   '',
-  rdStandalone
+  rdStandalone,
 );
 
 console.log('Patch react-dev-utils/launchEditor');
@@ -27,5 +34,5 @@ shell.sed(
   '-i',
   /require\('chalk'\)/g,
   '{red:f=>f,cyan:f=>f,green:f=>f}',
-  path.join(__dirname, '../node_modules/react-dev-utils/launchEditor.js')
+  path.join(__dirname, '../node_modules/react-dev-utils/launchEditor.js'),
 );


### PR DESCRIPTION
Due to `react-devtools-core` v4 breaking changes, and we stop used the same auto-update feed for [React Native Debugger v0.11](https://github.com/jhen0409/react-native-debugger/releases/tag/v0.11.0-beta-4), so it need show tip for manually upgrade in v0.10.