### PR TITLE
Update documentation for installing v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To use this app you need to ensure you are using the correct version of React Na
 
 We used different auto-update feed for `v0.10` and `v0.11`, so you won't see update tips of `v0.11` from `v0.10`.
 
+Install last release of v0.10 (0.10.7)
+
+`brew update && brew cask install https://raw.githubusercontent.com/caskroom/homebrew-cask/b6ac3795c1df9f97242481c0817b1165e3e6306a/Casks/react-native-debugger.rb`
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)


### PR DESCRIPTION
I found Github struggles to run blame on the .rb of react-native-debugger to get the last commit, thought this might help others running <= 0.61 RN versions quickly install instead of going through commits on the cask repo.