### PR TITLE
react-native-debugger-open: --host arg for custom hosts

### DIFF
--- a/npm-package/bin/rndebugger-open.js
+++ b/npm-package/bin/rndebugger-open.js
@@ -29,7 +29,7 @@ const argv = require('minimist')(process.argv.slice(2), {
     // Use expo packager port (getExpoPort) instead of RN packager default port (8081)
     'expo',
   ],
-  string: ['port'],
+  string: ['port', 'host'],
   default: {
     inject: true,
   },
@@ -37,7 +37,7 @@ const argv = require('minimist')(process.argv.slice(2), {
 
 let moduleName;
 argv.port = Number(argv.port) || (argv.expo ? getExpoPort() : defaultPort);
-if (argv.open && argv.port) {
+if (argv.open && (argv.port || argv.host)) {
   moduleName = '../lib/open';
 } else {
   moduleName = '../lib/main';

--- a/npm-package/src/open.js
+++ b/npm-package/src/open.js
@@ -44,8 +44,8 @@ function connectToRND(rndPath, log, cb) {
   });
 }
 
-export default ({ port }, cb) => {
-  const rndPath = `rndebugger://set-debugger-loc?host=localhost&port=${port}`;
+export default ({ port, host = 'localhost' }, cb) => {
+  const rndPath = `rndebugger://set-debugger-loc?host=${host}&port=${port}`;
 
   if (process.platform === 'darwin') {
     const env = Object.assign({}, process.env);


### PR DESCRIPTION
I'm forced to use a separate machine for running Metro bundler (couldn't get it to work under WSL 2), and specifying a debugger host different from `localhost` will be useful to anyone with the same problem.

#### Example Usage:
```sh
$ rndebugger-open --open --port 19001 --host 10.0.0.100
```