### PR TITLE
Fix tests and glibc bug for version 0.10.x

### DIFF
--- a/electron/window.js
+++ b/electron/window.js
@@ -96,9 +96,9 @@ export const createWindow = ({ iconPath, isPortSettingRequired, port }) => {
     minHeight: minSize,
     ...(increasePosition && winBounds && winBounds.x && winBounds.y
       ? {
-          x: winBounds.x + increasePosition,
-          y: winBounds.y + increasePosition,
-        }
+        x: winBounds.x + increasePosition,
+        y: winBounds.y + increasePosition,
+      }
       : {}),
     backgroundColor: '#272c37',
     tabbingIdentifier: 'rndebugger',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^3.2.0",
     "devtron": "^1.4.0",
-    "electron": "^7.1.14",
+    "electron": "^7.3.2",
     "electron-debug": "^1.5.0",
     "electron-devtools-installer": "^2.2.3",
     "electron-installer-dmg": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^3.2.0",
     "devtron": "^1.4.0",
-    "electron": "^7.1.9",
+    "electron": "^7.1.14",
     "electron-debug": "^1.5.0",
     "electron-devtools-installer": "^2.2.3",
     "electron-installer-dmg": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,7 +3543,7 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.264.tgz#ed837f44524d0601a7b2b7b6efd86e35753d0e27"
   integrity sha512-z8E7WkrrquCuGYv+kKyybuZIbdms+4PeHp7Zm2uIgEhAigP0bOwqXILItwj0YO73o+QyHY/7XtEfP5DsHOWQgQ==
 
-electron@^7.1.14:
+electron@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.2.tgz#184b69fe9089693e179b3b34effa975dfc8e505d"
   integrity sha512-5uSWVfCJogiPiU0G+RKi4ECnNs0gPNjAwYVE9KR7RXaOJYcpNIC5RFejaaUnuRoBssJ5B1n/5WU6wDUxvPajWQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,10 +3543,10 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.264.tgz#ed837f44524d0601a7b2b7b6efd86e35753d0e27"
   integrity sha512-z8E7WkrrquCuGYv+kKyybuZIbdms+4PeHp7Zm2uIgEhAigP0bOwqXILItwj0YO73o+QyHY/7XtEfP5DsHOWQgQ==
 
-electron@^7.1.9:
-  version "7.1.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.1.9.tgz#5053195d2e476a3ecd881ece4edf64f0a8c32fa3"
-  integrity sha512-gkzDr08XxRaNZhwPLRXYNXDaPuiAeCrRPcClowlDVfCLKi+kRNhzekZpfYUBq8DdZCD29D3rCtgc9IHjD/xuHw==
+electron@^7.1.14:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.2.tgz#184b69fe9089693e179b3b34effa975dfc8e505d"
+  integrity sha512-5uSWVfCJogiPiU0G+RKi4ECnNs0gPNjAwYVE9KR7RXaOJYcpNIC5RFejaaUnuRoBssJ5B1n/5WU6wDUxvPajWQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
An update to the latest 7.x electron framework fixes a defect with glibc that I have come up against, described here: https://github.com/electron/electron/pull/22338

I have also changed some indenting to make the tests pass.