### PR TITLE
Bump react-devtools-core to ~4.12.4

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -14,6 +14,6 @@
     "adbkit": "^2.11.0",
     "apollo-client-devtools": "^2.3.5",
     "electron-store": "^1.2.0",
-    "react-devtools-core": "~4.10.3"
+    "react-devtools-core": "~4.12.4"
   }
 }

--- a/dist/yarn.lock
+++ b/dist/yarn.lock
@@ -641,10 +641,10 @@ react-apollo@^2.5.0-rc.3:
     ts-invariant "^0.4.2"
     tslib "^1.9.3"
 
-react-devtools-core@~4.10.3:
-  version "4.10.3"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.10.3.tgz#30580721d7e9a1568a55b7107f2b6cdce6502e63"
-  integrity sha512-2CtceOczycfR1Th5B+lIPA1NnGODdbeTLTLZVCYmdXfdmvR5h1+cgr0f+R7HtWbTeIcG5PXUK1/YDnELP5opQA==
+react-devtools-core@~4.12.4:
+  version "4.12.4"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.12.4.tgz#50ed121d467f44b051d1f7d19694849db0365d52"
+  integrity sha512-hVCT7wRtA5xWclgLb3oA51RNBAlbuTauEYkqFX+qRAkPLVJoX8qdJnO7r+47SSUckD5vkBm3kaAhg6597m7gDA==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prop-types": "^15.6.1",
     "react": "^15.6.1",
     "react-dev-utils": "^4.2.1",
-    "react-devtools-core": "~4.10.3",
+    "react-devtools-core": "~4.12.4",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8815,10 +8815,10 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-devtools-core@~4.10.3:
-  version "4.10.3"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.10.3.tgz#30580721d7e9a1568a55b7107f2b6cdce6502e63"
-  integrity sha512-2CtceOczycfR1Th5B+lIPA1NnGODdbeTLTLZVCYmdXfdmvR5h1+cgr0f+R7HtWbTeIcG5PXUK1/YDnELP5opQA==
+react-devtools-core@~4.12.4:
+  version "4.12.4"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.12.4.tgz#50ed121d467f44b051d1f7d19694849db0365d52"
+  integrity sha512-hVCT7wRtA5xWclgLb3oA51RNBAlbuTauEYkqFX+qRAkPLVJoX8qdJnO7r+47SSUckD5vkBm3kaAhg6597m7gDA==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"


### PR DESCRIPTION
Fixes #584.

I've tested it works for RN >= 0.62, so this update will be landed as a patch. (v0.11.8)