### PR TITLE
copy $ sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For **macOS**, you can use [Homebrew Cask](https://caskroom.github.io) to instal
 ### < Homebrew 2.6.0
 
 ```bash
-brew update && brew cask install react-native-debugger
+brew update && brew install --cask react-native-debugger
 ```
 
 ### >= Homebrew 2.6.0

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ For **macOS**, you can use [Homebrew Cask](https://caskroom.github.io) to instal
 ### < Homebrew 2.6.0
 
 ```bash
-$ brew update && brew cask install react-native-debugger
+brew update && brew cask install react-native-debugger
 ```
 
 ### >= Homebrew 2.6.0
 
 ```bash
-$ brew install --cask react-native-debugger
+brew install --cask react-native-debugger
 ```
 
 This puts `React Native Debugger.app` in your `/applications/` folder.


### PR DESCRIPTION
when i click on copy icon this will copy full line including `$` which is not supported in terminal..