### PR TITLE
Feature: Add support for rndebugger: uri scheme on Linux

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -47,7 +47,7 @@ if (process.platform === 'linux') {
   if (!singleInstanceLock) {
     process.exit();
   } else {
-    app.on('second-instance', async (event, commandLine, workingDirectory) => {
+    app.on('second-instance', async (event, commandLine) => {
       await handleCommandLine(commandLine);
     });
   }
@@ -114,7 +114,7 @@ app.on('ready', async () => {
       defaultRNPackagerPorts = [query.port];
     }
   }
-  
+
   defaultRNPackagerPorts.forEach(port => {
     createWindow({ port, ...defaultOptions });
   });
@@ -139,6 +139,6 @@ app.on('ready', async () => {
 
 // Pass all certificate errors in favor of Network Inspect feature
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
-    event.preventDefault();
-    callback(true);
+  event.preventDefault();
+  callback(true);
 });

--- a/electron/url-handle/handleURL.js
+++ b/electron/url-handle/handleURL.js
@@ -19,17 +19,23 @@ const filterPaths = list => {
   return filteredList;
 };
 
-const handleURL = async (getWindow, path) => {
-  const route = url.parse(path);
-
+export const parseUrl = _url => {
+  const route = url.parse(_url);
   if (route.host !== 'set-debugger-loc') return;
-
   const { host, port, projectRoots } = qs.parse(route.query);
   const query = {
     host: host || 'localhost',
     port: Number(port) || 8081,
     projectRoots: Array.isArray(projectRoots) ? filterPaths(projectRoots.split(',')) : undefined,
   };
+  return query;
+}
+
+export const handleURL = async (getWindow, path) => {
+  const query = parseUrl(path);
+  if (!query) {
+    return;
+  }
   const payload = JSON.stringify(query);
 
   // This env will be get by new debugger window

--- a/electron/url-handle/handleURL.js
+++ b/electron/url-handle/handleURL.js
@@ -29,7 +29,7 @@ export const parseUrl = _url => {
     projectRoots: Array.isArray(projectRoots) ? filterPaths(projectRoots.split(',')) : undefined,
   };
   return query;
-}
+};
 
 export const handleURL = async (getWindow, path) => {
   const query = parseUrl(path);

--- a/electron/url-handle/index.js
+++ b/electron/url-handle/index.js
@@ -1,4 +1,4 @@
-import startListeningHandleURL from './handleURL';
+import startListeningHandleURL, { handleURL, parseUrl } from './handleURL';
 import * as port from './port';
 
-export { startListeningHandleURL, port };
+export { startListeningHandleURL, handleURL, parseUrl, port };

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -2,5 +2,6 @@
   "dest": "release/",
   "icon": "electron/logo.ico",
   "categories": ["Utility"],
-  "lintianOverrides": ["changelog-file-missing-in-native-package"]
+  "lintianOverrides": ["changelog-file-missing-in-native-package"],
+  "mimeType": ["x-scheme-handler/rndebugger"]
 }


### PR DESCRIPTION
Support `rndebugger:` URI scheme on Linux (via xdg-open):
- on Linux, use `app.requestSingleInstanceLock()`
- when opened the first time, the uri is read from precess.argv and the port in the URI takes precedence

Usage with Expo:
```shell
$ REACT_DEBUGGER="unset ELECTRON_RUN_AS_NODE && xdg-open 'rndebugger://set-debugger-loc?port=19000' ||" yarn start
```

Packagers for distributions not officially supported should add `MimeType=x-scheme-handler/rndebugger;` to the .desktop file