### PR TITLE
Don't check host for Open in Editor

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,8 +60,8 @@ window.open = (url, frameName, features = '') => {
 
 window.openInEditor = (file, lineNumber) => launchEditor(file, lineNumber);
 window.toggleOpenInEditor = () => {
-  const { host, port } = store.getState().debugger.location;
-  return toggleOpenInEditor(currentWindow, host, port);
+  const { port } = store.getState().debugger.location;
+  return toggleOpenInEditor(currentWindow, port);
 };
 window.isOpenInEditorEnabled = () => isOpenInEditorEnabled(currentWindow);
 

--- a/app/utils/devtools.js
+++ b/app/utils/devtools.js
@@ -1,11 +1,11 @@
 import { getCatchConsoleLogScript } from '../../electron/devtools';
 
 let enabled = false;
-export const toggleOpenInEditor = (win, host, port) => {
+export const toggleOpenInEditor = (win, port) => {
   if (win.devToolsWebContents) {
     enabled = !enabled;
     return win.devToolsWebContents.executeJavaScript(`(() => {
-      ${getCatchConsoleLogScript(host, port)}
+      ${getCatchConsoleLogScript(port)}
       window.__IS_OPEN_IN_EDITOR_ENABLED__ = ${enabled};
     })()`);
   }

--- a/electron/devtools.js
+++ b/electron/devtools.js
@@ -1,5 +1,5 @@
-export const getCatchConsoleLogScript = (host, port) => `
-  window.__RN_PACKAGER_PREFIX__ = 'http://${host}:${port}';
+export const getCatchConsoleLogScript = (port) => `
+  window.__RN_PACKAGER_MATCHER__ = /^http:\\/\\/[^:]+:${port}/;
   if (!window.__INJECT_OPEN_IN_EDITOR_SCRIPT__) {
     const rndHelperQuery = 'iframe[data-devtools-extension="RNDebugger devtools helper"]';
     document.addEventListener('click', event => {
@@ -9,13 +9,13 @@ export const getCatchConsoleLogScript = (host, port) => `
       const { target } = event;
       if (target.className === 'devtools-link') {
         const source = target.title;
-        if (source && source.startsWith(window.__RN_PACKAGER_PREFIX__)) {
+        if (source && source.match(window.__RN_PACKAGER_MATCHER__)) {
           const rndHelper = document.querySelector(rndHelperQuery);
           if (rndHelper && rndHelper.contentWindow) {
             rndHelper.contentWindow.postMessage(
               {
                 type: 'open-in-editor',
-                source: source.replace(window.__RN_PACKAGER_PREFIX__, ''),
+                source: source.replace(window.__RN_PACKAGER_MATCHER__, '')
               },
               '*'
             );


### PR DESCRIPTION
The file link of RN packager like Expo 48 is using IP as host, it doesn't work if set the host as `localhost` in `__RN_PACKAGER_PREFIX__`. Remove the host check is probably works fine on most use cases.